### PR TITLE
Added multiple templates support

### DIFF
--- a/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
+++ b/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
@@ -11,7 +11,6 @@ using System.Timers;
 using WinampNowPlayingToFile.Facade;
 using WinampNowPlayingToFile.Settings;
 using Song = WinampNowPlayingToFile.Facade.Song;
-using static WinampNowPlayingToFile.Settings.ISettings;
 using System.Drawing.Text;
 
 namespace WinampNowPlayingToFile.Business;

--- a/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
+++ b/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
@@ -11,6 +11,9 @@ using System.Timers;
 using WinampNowPlayingToFile.Facade;
 using WinampNowPlayingToFile.Settings;
 using Song = WinampNowPlayingToFile.Facade.Song;
+using static WinampNowPlayingToFile.Settings.ISettings;
+using System.Drawing.Text;
+//using System.Windows.Forms;
 
 namespace WinampNowPlayingToFile.Business;
 
@@ -36,7 +39,13 @@ public class NowPlayingToFileManager: INowPlayingToFileManager {
     private readonly  FormatCompiler   templateCompiler = new();
     internal readonly Timer            renderTextTimer  = new(1000);
 
-    private Generator? cachedTemplate;
+    internal struct templateWithGenerator {
+        internal string fileName { get; set; }
+        internal Generator generator { get; set; }
+    }
+
+    private List<templateWithGenerator> cachedTemplates = new List<templateWithGenerator>();
+
     private bool       _textTemplateDependsOnTime;
 
     private bool textTemplateDependsOnTime {
@@ -63,7 +72,7 @@ public class NowPlayingToFileManager: INowPlayingToFileManager {
         };
 
         this.settings.settingsUpdated += delegate {
-            cachedTemplate            = null;
+            cachedTemplates.Clear();
             textTemplateDependsOnTime = false;
             update();
         };
@@ -82,7 +91,9 @@ public class NowPlayingToFileManager: INowPlayingToFileManager {
     internal void update(bool updateAlbumArt = true) {
         try {
             if (winampController.currentSong is { Filename: not "" } currentSong) {
-                saveText(renderText(currentSong));
+                foreach (textTemplate template in settings.textTemplates) {
+                    saveText(template.fileName, renderText(currentSong, template));
+                }
 
                 if (updateAlbumArt) {
                     saveImage(findAlbumArt(currentSong));
@@ -93,21 +104,24 @@ public class NowPlayingToFileManager: INowPlayingToFileManager {
         }
     }
 
-    internal string renderText(Song currentSong) {
-        return winampController.status == Status.Playing ? getTemplate().Render(currentSong) : string.Empty;
+    internal string renderText(Song currentSong, textTemplate template) {
+        return winampController.status == Status.Playing ? getTemplate(template).Render(currentSong) : string.Empty;
     }
 
-    private void saveText(string nowPlayingText) {
-        File.WriteAllText(settings.textFilename, nowPlayingText, UTF8);
+    private void saveText(string fileName, string nowPlayingText) {
+        File.WriteAllText(fileName, nowPlayingText, UTF8);
     }
 
-    private Generator getTemplate() {
-        if (cachedTemplate == null) {
-            cachedTemplate             =  templateCompiler.Compile(settings.textTemplate);
-            cachedTemplate.KeyNotFound += fetchExtraMetadata;
+    private Generator getTemplate(textTemplate template) {
+        Generator templateGenerator;
+        if (cachedTemplates.Exists(x => x.fileName == template.fileName)) {
+            templateGenerator = cachedTemplates.Single(x => x.fileName == template.fileName).generator;
+        } else {
+            templateGenerator = templateCompiler.Compile(template.text);
+            templateGenerator.KeyNotFound += fetchExtraMetadata;
+            cachedTemplates.Add(new templateWithGenerator() { fileName = template.fileName, generator = templateGenerator });
         }
-
-        return cachedTemplate;
+        return templateGenerator;
     }
 
     private void fetchExtraMetadata(object sender, KeyNotFoundEventArgs args) {
@@ -211,7 +225,9 @@ public class NowPlayingToFileManager: INowPlayingToFileManager {
 
     public virtual void onQuit() {
         renderTextTimer.Stop();
-        saveText(string.Empty);
+        foreach (textTemplate template in settings.textTemplates) {
+            saveText(template.fileName, string.Empty);
+		}
         saveImage(albumArtWhenStopped);
     }
 

--- a/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
+++ b/WinampNowPlayingToFile/Business/NowPlayingToFileManager.cs
@@ -13,7 +13,6 @@ using WinampNowPlayingToFile.Settings;
 using Song = WinampNowPlayingToFile.Facade.Song;
 using static WinampNowPlayingToFile.Settings.ISettings;
 using System.Drawing.Text;
-//using System.Windows.Forms;
 
 namespace WinampNowPlayingToFile.Business;
 

--- a/WinampNowPlayingToFile/Facade/textTemplate.cs
+++ b/WinampNowPlayingToFile/Facade/textTemplate.cs
@@ -1,0 +1,16 @@
+﻿namespace WinampNowPlayingToFile.Facade;
+
+public struct textTemplate {
+	public textTemplate(string fileName = null!, string text = null!) {
+        this.fileName = fileName!;
+        this.text = text!;
+	}
+
+	public string fileName { get; set; }
+    public string text { get; set; }
+
+	public override string ToString() {
+		return text;
+	}
+}
+

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
@@ -95,14 +95,10 @@
 			this.albumArtBrowseButton = new System.Windows.Forms.Button();
 			this.albumArtFilename = new System.Windows.Forms.TextBox();
 			this.albumArtFilenameEditor = new System.Windows.Forms.SaveFileDialog();
-			this.writeToFile2Label = new System.Windows.Forms.Label();
-			this.text2BrowseButton = new System.Windows.Forms.Button();
-			this.text2Filename = new System.Windows.Forms.TextBox();
-			this.template2Label = new System.Windows.Forms.Label();
-			this.preview2Label = new System.Windows.Forms.Label();
-			this.template2Editor = new System.Windows.Forms.TextBox();
-			this.template2InsertButton = new System.Windows.Forms.Button();
-			this.template2Preview = new System.Windows.Forms.TextBox();
+			this.templateSelector = new System.Windows.Forms.ComboBox();
+			this.templateSelectorLabel = new System.Windows.Forms.Label();
+			this.button1 = new System.Windows.Forms.Button();
+			this.button2 = new System.Windows.Forms.Button();
 			albumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			artistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			filenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -467,7 +463,7 @@
 			// writeToFileLabel
 			// 
 			this.writeToFileLabel.AutoSize = true;
-			this.writeToFileLabel.Location = new System.Drawing.Point(13, 76);
+			this.writeToFileLabel.Location = new System.Drawing.Point(13, 102);
 			this.writeToFileLabel.Name = "writeToFileLabel";
 			this.writeToFileLabel.Size = new System.Drawing.Size(66, 13);
 			this.writeToFileLabel.TabIndex = 5;
@@ -483,7 +479,7 @@
 			// textBrowseButton
 			// 
 			this.textBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.textBrowseButton.Location = new System.Drawing.Point(499, 71);
+			this.textBrowseButton.Location = new System.Drawing.Point(499, 97);
 			this.textBrowseButton.Name = "textBrowseButton";
 			this.textBrowseButton.Size = new System.Drawing.Size(75, 23);
 			this.textBrowseButton.TabIndex = 7;
@@ -495,16 +491,16 @@
 			// 
 			this.textFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.textFilename.Location = new System.Drawing.Point(140, 73);
+			this.textFilename.Location = new System.Drawing.Point(119, 99);
 			this.textFilename.Name = "textFilename";
-			this.textFilename.Size = new System.Drawing.Size(353, 20);
+			this.textFilename.Size = new System.Drawing.Size(374, 20);
 			this.textFilename.TabIndex = 6;
 			this.textFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
 			// 
 			// templateLabel
 			// 
 			this.templateLabel.AutoSize = true;
-			this.templateLabel.Location = new System.Drawing.Point(13, 18);
+			this.templateLabel.Location = new System.Drawing.Point(13, 44);
 			this.templateLabel.Name = "templateLabel";
 			this.templateLabel.Size = new System.Drawing.Size(71, 13);
 			this.templateLabel.TabIndex = 0;
@@ -514,16 +510,16 @@
 			// 
 			this.templateEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.templateEditor.Location = new System.Drawing.Point(140, 15);
+			this.templateEditor.Location = new System.Drawing.Point(119, 41);
 			this.templateEditor.Name = "templateEditor";
-			this.templateEditor.Size = new System.Drawing.Size(353, 20);
+			this.templateEditor.Size = new System.Drawing.Size(374, 20);
 			this.templateEditor.TabIndex = 1;
 			this.templateEditor.TextChanged += new System.EventHandler(this.onTemplateChange);
 			// 
 			// templateInsertButton
 			// 
 			this.templateInsertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.templateInsertButton.Location = new System.Drawing.Point(499, 13);
+			this.templateInsertButton.Location = new System.Drawing.Point(499, 39);
 			this.templateInsertButton.Name = "templateInsertButton";
 			this.templateInsertButton.Size = new System.Drawing.Size(75, 23);
 			this.templateInsertButton.TabIndex = 2;
@@ -534,7 +530,7 @@
 			// okButton
 			// 
 			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.okButton.Location = new System.Drawing.Point(337, 267);
+			this.okButton.Location = new System.Drawing.Point(337, 220);
 			this.okButton.Name = "okButton";
 			this.okButton.Size = new System.Drawing.Size(75, 23);
 			this.okButton.TabIndex = 13;
@@ -546,7 +542,7 @@
 			// 
 			this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancelButton.Location = new System.Drawing.Point(418, 267);
+			this.cancelButton.Location = new System.Drawing.Point(418, 220);
 			this.cancelButton.Name = "cancelButton";
 			this.cancelButton.Size = new System.Drawing.Size(75, 23);
 			this.cancelButton.TabIndex = 14;
@@ -558,17 +554,17 @@
 			// 
 			this.templatePreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.templatePreview.Location = new System.Drawing.Point(140, 44);
+			this.templatePreview.Location = new System.Drawing.Point(119, 70);
 			this.templatePreview.Name = "templatePreview";
 			this.templatePreview.ReadOnly = true;
-			this.templatePreview.Size = new System.Drawing.Size(434, 20);
+			this.templatePreview.Size = new System.Drawing.Size(455, 20);
 			this.templatePreview.TabIndex = 4;
 			this.templatePreview.TabStop = false;
 			// 
 			// previewLabel
 			// 
 			this.previewLabel.AutoSize = true;
-			this.previewLabel.Location = new System.Drawing.Point(13, 47);
+			this.previewLabel.Location = new System.Drawing.Point(13, 73);
 			this.previewLabel.Name = "previewLabel";
 			this.previewLabel.Size = new System.Drawing.Size(68, 13);
 			this.previewLabel.TabIndex = 3;
@@ -634,7 +630,7 @@
 			this.explanationLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.explanationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-			this.explanationLabel.Location = new System.Drawing.Point(30, 234);
+			this.explanationLabel.Location = new System.Drawing.Point(30, 170);
 			this.explanationLabel.Name = "explanationLabel";
 			this.explanationLabel.Size = new System.Drawing.Size(544, 30);
 			this.explanationLabel.TabIndex = 12;
@@ -646,7 +642,7 @@
 			this.horizontalRule1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
 			this.horizontalRule1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-			this.horizontalRule1.Location = new System.Drawing.Point(16, 219);
+			this.horizontalRule1.Location = new System.Drawing.Point(16, 155);
 			this.horizontalRule1.Name = "horizontalRule1";
 			this.horizontalRule1.Size = new System.Drawing.Size(555, 2);
 			this.horizontalRule1.TabIndex = 11;
@@ -654,7 +650,7 @@
 			// applyButton
 			// 
 			this.applyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.applyButton.Location = new System.Drawing.Point(499, 267);
+			this.applyButton.Location = new System.Drawing.Point(499, 220);
 			this.applyButton.Name = "applyButton";
 			this.applyButton.Size = new System.Drawing.Size(75, 23);
 			this.applyButton.TabIndex = 15;
@@ -665,7 +661,7 @@
 			// albumArtLabel
 			// 
 			this.albumArtLabel.AutoSize = true;
-			this.albumArtLabel.Location = new System.Drawing.Point(13, 192);
+			this.albumArtLabel.Location = new System.Drawing.Point(13, 128);
 			this.albumArtLabel.Name = "albumArtLabel";
 			this.albumArtLabel.Size = new System.Drawing.Size(92, 13);
 			this.albumArtLabel.TabIndex = 8;
@@ -674,7 +670,7 @@
 			// albumArtBrowseButton
 			// 
 			this.albumArtBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.albumArtBrowseButton.Location = new System.Drawing.Point(499, 187);
+			this.albumArtBrowseButton.Location = new System.Drawing.Point(499, 123);
 			this.albumArtBrowseButton.Name = "albumArtBrowseButton";
 			this.albumArtBrowseButton.Size = new System.Drawing.Size(75, 23);
 			this.albumArtBrowseButton.TabIndex = 10;
@@ -686,9 +682,9 @@
 			// 
 			this.albumArtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-			this.albumArtFilename.Location = new System.Drawing.Point(140, 189);
+			this.albumArtFilename.Location = new System.Drawing.Point(119, 125);
 			this.albumArtFilename.Name = "albumArtFilename";
-			this.albumArtFilename.Size = new System.Drawing.Size(353, 20);
+			this.albumArtFilename.Size = new System.Drawing.Size(374, 20);
 			this.albumArtFilename.TabIndex = 9;
 			this.albumArtFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
 			// 
@@ -699,85 +695,40 @@
 			this.albumArtFilenameEditor.Title = "Choose file to save Now Playing album art into";
 			this.albumArtFilenameEditor.FileOk += new System.ComponentModel.CancelEventHandler(this.onSubmitFilename);
 			// 
-			// writeToFile2Label
+			// templateSelector
 			// 
-			this.writeToFile2Label.AutoSize = true;
-			this.writeToFile2Label.Location = new System.Drawing.Point(13, 163);
-			this.writeToFile2Label.Name = "writeToFile2Label";
-			this.writeToFile2Label.Size = new System.Drawing.Size(118, 13);
-			this.writeToFile2Label.TabIndex = 5;
-			this.writeToFile2Label.Text = "&Save secondary text as";
+			this.templateSelector.FormattingEnabled = true;
+			this.templateSelector.Location = new System.Drawing.Point(119, 12);
+			this.templateSelector.Name = "templateSelector";
+			this.templateSelector.Size = new System.Drawing.Size(374, 21);
+			this.templateSelector.TabIndex = 16;
 			// 
-			// text2BrowseButton
+			// templateSelectorLabel
 			// 
-			this.text2BrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.text2BrowseButton.Location = new System.Drawing.Point(499, 158);
-			this.text2BrowseButton.Name = "text2BrowseButton";
-			this.text2BrowseButton.Size = new System.Drawing.Size(75, 23);
-			this.text2BrowseButton.TabIndex = 7;
-			this.text2BrowseButton.Text = "&Browse…";
-			this.text2BrowseButton.UseVisualStyleBackColor = true;
-			this.text2BrowseButton.Click += new System.EventHandler(this.onTextFileBrowseButtonClick);
+			this.templateSelectorLabel.AutoSize = true;
+			this.templateSelectorLabel.Location = new System.Drawing.Point(13, 15);
+			this.templateSelectorLabel.Name = "templateSelectorLabel";
+			this.templateSelectorLabel.Size = new System.Drawing.Size(80, 13);
+			this.templateSelectorLabel.TabIndex = 17;
+			this.templateSelectorLabel.Text = "Select template";
 			// 
-			// text2Filename
+			// button1
 			// 
-			this.text2Filename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.text2Filename.Location = new System.Drawing.Point(140, 160);
-			this.text2Filename.Name = "text2Filename";
-			this.text2Filename.Size = new System.Drawing.Size(353, 20);
-			this.text2Filename.TabIndex = 6;
-			this.text2Filename.TextChanged += new System.EventHandler(this.onFilenameChange);
+			this.button1.Location = new System.Drawing.Point(539, 10);
+			this.button1.Name = "button1";
+			this.button1.Size = new System.Drawing.Size(35, 23);
+			this.button1.TabIndex = 18;
+			this.button1.Text = "+";
+			this.button1.UseVisualStyleBackColor = true;
 			// 
-			// template2Label
+			// button2
 			// 
-			this.template2Label.AutoSize = true;
-			this.template2Label.Location = new System.Drawing.Point(13, 105);
-			this.template2Label.Name = "template2Label";
-			this.template2Label.Size = new System.Drawing.Size(121, 13);
-			this.template2Label.TabIndex = 0;
-			this.template2Label.Text = "&Secondary text template";
-			// 
-			// preview2Label
-			// 
-			this.preview2Label.AutoSize = true;
-			this.preview2Label.Location = new System.Drawing.Point(13, 134);
-			this.preview2Label.Name = "preview2Label";
-			this.preview2Label.Size = new System.Drawing.Size(118, 13);
-			this.preview2Label.TabIndex = 3;
-			this.preview2Label.Text = "Secondary text preview";
-			// 
-			// template2Editor
-			// 
-			this.template2Editor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.template2Editor.Location = new System.Drawing.Point(140, 102);
-			this.template2Editor.Name = "template2Editor";
-			this.template2Editor.Size = new System.Drawing.Size(353, 20);
-			this.template2Editor.TabIndex = 1;
-			this.template2Editor.TextChanged += new System.EventHandler(this.onTemplateChange);
-			// 
-			// template2InsertButton
-			// 
-			this.template2InsertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-			this.template2InsertButton.Location = new System.Drawing.Point(499, 100);
-			this.template2InsertButton.Name = "template2InsertButton";
-			this.template2InsertButton.Size = new System.Drawing.Size(75, 23);
-			this.template2InsertButton.TabIndex = 2;
-			this.template2InsertButton.Text = "&Insert";
-			this.template2InsertButton.UseVisualStyleBackColor = true;
-			this.template2InsertButton.Click += new System.EventHandler(this.showTemplateMenu);
-			// 
-			// template2Preview
-			// 
-			this.template2Preview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-			this.template2Preview.Location = new System.Drawing.Point(140, 131);
-			this.template2Preview.Name = "template2Preview";
-			this.template2Preview.ReadOnly = true;
-			this.template2Preview.Size = new System.Drawing.Size(434, 20);
-			this.template2Preview.TabIndex = 4;
-			this.template2Preview.TabStop = false;
+			this.button2.Location = new System.Drawing.Point(499, 10);
+			this.button2.Name = "button2";
+			this.button2.Size = new System.Drawing.Size(35, 23);
+			this.button2.TabIndex = 18;
+			this.button2.Text = "-";
+			this.button2.UseVisualStyleBackColor = true;
 			// 
 			// SettingsDialog
 			// 
@@ -785,29 +736,25 @@
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.cancelButton;
-			this.ClientSize = new System.Drawing.Size(586, 303);
+			this.ClientSize = new System.Drawing.Size(586, 256);
+			this.Controls.Add(this.button2);
+			this.Controls.Add(this.button1);
+			this.Controls.Add(this.templateSelectorLabel);
+			this.Controls.Add(this.templateSelector);
 			this.Controls.Add(this.applyButton);
 			this.Controls.Add(this.horizontalRule1);
 			this.Controls.Add(this.explanationLabel);
-			this.Controls.Add(this.template2Preview);
 			this.Controls.Add(this.templatePreview);
 			this.Controls.Add(this.cancelButton);
 			this.Controls.Add(this.okButton);
-			this.Controls.Add(this.template2InsertButton);
 			this.Controls.Add(this.templateInsertButton);
-			this.Controls.Add(this.template2Editor);
 			this.Controls.Add(this.templateEditor);
-			this.Controls.Add(this.preview2Label);
 			this.Controls.Add(this.previewLabel);
-			this.Controls.Add(this.template2Label);
 			this.Controls.Add(this.templateLabel);
 			this.Controls.Add(this.albumArtFilename);
-			this.Controls.Add(this.text2Filename);
 			this.Controls.Add(this.textFilename);
-			this.Controls.Add(this.text2BrowseButton);
 			this.Controls.Add(this.albumArtBrowseButton);
 			this.Controls.Add(this.textBrowseButton);
-			this.Controls.Add(this.writeToFile2Label);
 			this.Controls.Add(this.albumArtLabel);
 			this.Controls.Add(this.writeToFileLabel);
 			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
@@ -852,13 +799,9 @@
         private System.Windows.Forms.ToolStripMenuItem fileBasenameToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fileBasenameWithoutExtensionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem otherToolStripMenuItem;
-		private System.Windows.Forms.Label writeToFile2Label;
-		private System.Windows.Forms.Button text2BrowseButton;
-		private System.Windows.Forms.TextBox text2Filename;
-		private System.Windows.Forms.Label template2Label;
-		private System.Windows.Forms.Label preview2Label;
-		private System.Windows.Forms.TextBox template2Editor;
-		private System.Windows.Forms.Button template2InsertButton;
-		private System.Windows.Forms.TextBox template2Preview;
+		private System.Windows.Forms.ComboBox templateSelector;
+		private System.Windows.Forms.Label templateSelectorLabel;
+		private System.Windows.Forms.Button button1;
+		private System.Windows.Forms.Button button2;
 	}
 }

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
@@ -97,8 +97,8 @@
 			this.albumArtFilenameEditor = new System.Windows.Forms.SaveFileDialog();
 			this.templateSelector = new System.Windows.Forms.ComboBox();
 			this.templateSelectorLabel = new System.Windows.Forms.Label();
-			this.button1 = new System.Windows.Forms.Button();
-			this.button2 = new System.Windows.Forms.Button();
+			this.templateAdd = new System.Windows.Forms.Button();
+			this.templateRemove = new System.Windows.Forms.Button();
 			albumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			artistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			filenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -697,11 +697,13 @@
 			// 
 			// templateSelector
 			// 
+			this.templateSelector.DropDownStyle = System.Windows.Forms.ComboBoxStyle.DropDownList;
 			this.templateSelector.FormattingEnabled = true;
 			this.templateSelector.Location = new System.Drawing.Point(119, 12);
 			this.templateSelector.Name = "templateSelector";
 			this.templateSelector.Size = new System.Drawing.Size(374, 21);
 			this.templateSelector.TabIndex = 16;
+			this.templateSelector.SelectedIndexChanged += new System.EventHandler(this.onTemplateSelectorChanged);
 			// 
 			// templateSelectorLabel
 			// 
@@ -712,23 +714,25 @@
 			this.templateSelectorLabel.TabIndex = 17;
 			this.templateSelectorLabel.Text = "Select template";
 			// 
-			// button1
+			// templateAdd
 			// 
-			this.button1.Location = new System.Drawing.Point(539, 10);
-			this.button1.Name = "button1";
-			this.button1.Size = new System.Drawing.Size(35, 23);
-			this.button1.TabIndex = 18;
-			this.button1.Text = "+";
-			this.button1.UseVisualStyleBackColor = true;
+			this.templateAdd.Location = new System.Drawing.Point(539, 10);
+			this.templateAdd.Name = "templateAdd";
+			this.templateAdd.Size = new System.Drawing.Size(35, 23);
+			this.templateAdd.TabIndex = 18;
+			this.templateAdd.Text = "+";
+			this.templateAdd.UseVisualStyleBackColor = true;
+			this.templateAdd.Click += new System.EventHandler(this.onTemplateAdd);
 			// 
-			// button2
+			// templateRemove
 			// 
-			this.button2.Location = new System.Drawing.Point(499, 10);
-			this.button2.Name = "button2";
-			this.button2.Size = new System.Drawing.Size(35, 23);
-			this.button2.TabIndex = 18;
-			this.button2.Text = "-";
-			this.button2.UseVisualStyleBackColor = true;
+			this.templateRemove.Location = new System.Drawing.Point(499, 10);
+			this.templateRemove.Name = "templateRemove";
+			this.templateRemove.Size = new System.Drawing.Size(35, 23);
+			this.templateRemove.TabIndex = 18;
+			this.templateRemove.Text = "-";
+			this.templateRemove.UseVisualStyleBackColor = true;
+			this.templateRemove.Click += new System.EventHandler(this.onTemmplateRemove);
 			// 
 			// SettingsDialog
 			// 
@@ -737,8 +741,8 @@
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.cancelButton;
 			this.ClientSize = new System.Drawing.Size(586, 256);
-			this.Controls.Add(this.button2);
-			this.Controls.Add(this.button1);
+			this.Controls.Add(this.templateRemove);
+			this.Controls.Add(this.templateAdd);
 			this.Controls.Add(this.templateSelectorLabel);
 			this.Controls.Add(this.templateSelector);
 			this.Controls.Add(this.applyButton);
@@ -801,7 +805,7 @@
         private System.Windows.Forms.ToolStripMenuItem otherToolStripMenuItem;
 		private System.Windows.Forms.ComboBox templateSelector;
 		private System.Windows.Forms.Label templateSelectorLabel;
-		private System.Windows.Forms.Button button1;
-		private System.Windows.Forms.Button button2;
+		private System.Windows.Forms.Button templateAdd;
+		private System.Windows.Forms.Button templateRemove;
 	}
 }

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
@@ -28,379 +28,387 @@
         /// </summary>
         private void InitializeComponent()
         {
-            this.components = new System.ComponentModel.Container();
-            System.Windows.Forms.ToolStripMenuItem albumToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem artistToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem filenameToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem titleToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem yearToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem albumArtistToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem bitrateToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem bpmToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem categoryToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem commentToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem composerToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem conductorToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem directorToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem discToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem familyToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem gainToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem genreToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem isrcToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem keyToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem lengthToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem losslessToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem lyricistToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem mediaToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem producerToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem publisherToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem ratingToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem replayGainAlbumGainToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem replayGainAlbumPeakToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem replayGainTrackGainToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem replayGainTrackPeakToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem stereoToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem subtitleToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem toolToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem trackToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem typeToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem vbrToolStripMenuItem;
-            System.Windows.Forms.ToolStripMenuItem elapsedToolStripMenuItem;
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
-            this.otherToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileBasenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.fileBasenameWithoutExtensionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.writeToFileLabel = new System.Windows.Forms.Label();
-            this.textFilenameEditor = new System.Windows.Forms.SaveFileDialog();
-            this.textBrowseButton = new System.Windows.Forms.Button();
-            this.textFilename = new System.Windows.Forms.TextBox();
-            this.templateLabel = new System.Windows.Forms.Label();
-            this.templateEditor = new System.Windows.Forms.TextBox();
-            this.templateInsertButton = new System.Windows.Forms.Button();
-            this.okButton = new System.Windows.Forms.Button();
-            this.cancelButton = new System.Windows.Forms.Button();
-            this.templatePreview = new System.Windows.Forms.TextBox();
-            this.previewLabel = new System.Windows.Forms.Label();
-            this.insertTemplatePlaceholderMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
-            this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
-            this.ifToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.ifElseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.newLineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
-            this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.explanationLabel = new System.Windows.Forms.Label();
-            this.horizontalRule1 = new System.Windows.Forms.Label();
-            this.applyButton = new System.Windows.Forms.Button();
-            this.albumArtLabel = new System.Windows.Forms.Label();
-            this.albumArtBrowseButton = new System.Windows.Forms.Button();
-            this.albumArtFilename = new System.Windows.Forms.TextBox();
-            this.albumArtFilenameEditor = new System.Windows.Forms.SaveFileDialog();
-            albumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            artistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            filenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            titleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            yearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            albumArtistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            bitrateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            bpmToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            categoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            commentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            composerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            conductorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            directorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            discToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            familyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            gainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            genreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            isrcToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            keyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            lengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            losslessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            lyricistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            mediaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            producerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            publisherToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            ratingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            replayGainAlbumGainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            replayGainAlbumPeakToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            replayGainTrackGainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            replayGainTrackPeakToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            stereoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            subtitleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            toolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            trackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            typeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            vbrToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            elapsedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
-            this.insertTemplatePlaceholderMenu.SuspendLayout();
-            this.SuspendLayout();
-            // 
-            // albumToolStripMenuItem
-            // 
-            albumToolStripMenuItem.Name = "albumToolStripMenuItem";
-            albumToolStripMenuItem.ShowShortcutKeys = false;
-            albumToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            albumToolStripMenuItem.Text = "Album";
-            // 
-            // artistToolStripMenuItem
-            // 
-            artistToolStripMenuItem.Name = "artistToolStripMenuItem";
-            artistToolStripMenuItem.ShowShortcutKeys = false;
-            artistToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            artistToolStripMenuItem.Text = "Artist";
-            // 
-            // filenameToolStripMenuItem
-            // 
-            filenameToolStripMenuItem.Name = "filenameToolStripMenuItem";
-            filenameToolStripMenuItem.ShowShortcutKeys = false;
-            filenameToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            filenameToolStripMenuItem.Text = "Filename";
-            filenameToolStripMenuItem.ToolTipText = "The absolute path to the file, e.g. \"C:\\Users\\Ben\\Music\\Song.mp3\"";
-            // 
-            // titleToolStripMenuItem
-            // 
-            titleToolStripMenuItem.Name = "titleToolStripMenuItem";
-            titleToolStripMenuItem.ShowShortcutKeys = false;
-            titleToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            titleToolStripMenuItem.Text = "Title";
-            // 
-            // yearToolStripMenuItem
-            // 
-            yearToolStripMenuItem.Name = "yearToolStripMenuItem";
-            yearToolStripMenuItem.ShowShortcutKeys = false;
-            yearToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            yearToolStripMenuItem.Text = "Year";
-            // 
-            // albumArtistToolStripMenuItem
-            // 
-            albumArtistToolStripMenuItem.Name = "albumArtistToolStripMenuItem";
-            albumArtistToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            albumArtistToolStripMenuItem.Tag = "AlbumArtist";
-            albumArtistToolStripMenuItem.Text = "Album artist";
-            // 
-            // bitrateToolStripMenuItem
-            // 
-            bitrateToolStripMenuItem.Name = "bitrateToolStripMenuItem";
-            bitrateToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            bitrateToolStripMenuItem.Text = "Bitrate";
-            bitrateToolStripMenuItem.ToolTipText = "Number of kilobits per second, e.g. \"320\"";
-            // 
-            // bpmToolStripMenuItem
-            // 
-            bpmToolStripMenuItem.Name = "bpmToolStripMenuItem";
-            bpmToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            bpmToolStripMenuItem.Tag = "BPM";
-            bpmToolStripMenuItem.Text = "BPM";
-            bpmToolStripMenuItem.ToolTipText = "Number of beats per minute, e.g. \"86\"";
-            // 
-            // categoryToolStripMenuItem
-            // 
-            categoryToolStripMenuItem.Name = "categoryToolStripMenuItem";
-            categoryToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            categoryToolStripMenuItem.Text = "Category";
-            categoryToolStripMenuItem.ToolTipText = "e.g. \"Rock\"";
-            // 
-            // commentToolStripMenuItem
-            // 
-            commentToolStripMenuItem.Name = "commentToolStripMenuItem";
-            commentToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            commentToolStripMenuItem.Text = "Comment";
-            // 
-            // composerToolStripMenuItem
-            // 
-            composerToolStripMenuItem.Name = "composerToolStripMenuItem";
-            composerToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            composerToolStripMenuItem.Text = "Composer";
-            // 
-            // conductorToolStripMenuItem
-            // 
-            conductorToolStripMenuItem.Name = "conductorToolStripMenuItem";
-            conductorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            conductorToolStripMenuItem.Text = "Conductor";
-            // 
-            // directorToolStripMenuItem
-            // 
-            directorToolStripMenuItem.Name = "directorToolStripMenuItem";
-            directorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            directorToolStripMenuItem.Text = "Director";
-            directorToolStripMenuItem.ToolTipText = "For video files";
-            // 
-            // discToolStripMenuItem
-            // 
-            discToolStripMenuItem.Name = "discToolStripMenuItem";
-            discToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            discToolStripMenuItem.Text = "Disc";
-            discToolStripMenuItem.ToolTipText = "e.g. \"1\" or \"1/2\"";
-            // 
-            // familyToolStripMenuItem
-            // 
-            familyToolStripMenuItem.Name = "familyToolStripMenuItem";
-            familyToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            familyToolStripMenuItem.Text = "Family";
-            familyToolStripMenuItem.ToolTipText = "e.g. \"MPEG Layer 3 Audio File\"";
-            // 
-            // gainToolStripMenuItem
-            // 
-            gainToolStripMenuItem.Name = "gainToolStripMenuItem";
-            gainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            gainToolStripMenuItem.Text = "Gain";
-            gainToolStripMenuItem.ToolTipText = "e.g. \"+0.40 dB\"";
-            // 
-            // genreToolStripMenuItem
-            // 
-            genreToolStripMenuItem.Name = "genreToolStripMenuItem";
-            genreToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            genreToolStripMenuItem.Text = "Genre";
-            // 
-            // isrcToolStripMenuItem
-            // 
-            isrcToolStripMenuItem.Name = "isrcToolStripMenuItem";
-            isrcToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            isrcToolStripMenuItem.Tag = "ISRC";
-            isrcToolStripMenuItem.Text = "ISRC";
-            isrcToolStripMenuItem.ToolTipText = "e.g. \"USLZJ2006066\"";
-            // 
-            // keyToolStripMenuItem
-            // 
-            keyToolStripMenuItem.Name = "keyToolStripMenuItem";
-            keyToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            keyToolStripMenuItem.Text = "Key";
-            keyToolStripMenuItem.ToolTipText = "e.g. \"A\"";
-            // 
-            // lengthToolStripMenuItem
-            // 
-            lengthToolStripMenuItem.Name = "lengthToolStripMenuItem";
-            lengthToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            lengthToolStripMenuItem.Tag = "Length:m\\:ss";
-            lengthToolStripMenuItem.Text = "Length";
-            lengthToolStripMenuItem.ToolTipText = "Duration of media with millisecond resolution, to be formatted as a .NET TimeSpan" +
+			this.components = new System.ComponentModel.Container();
+			System.Windows.Forms.ToolStripMenuItem albumToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem artistToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem filenameToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem titleToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem yearToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem albumArtistToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem bitrateToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem bpmToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem categoryToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem commentToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem composerToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem conductorToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem directorToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem discToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem familyToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem gainToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem genreToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem isrcToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem keyToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem lengthToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem losslessToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem lyricistToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem mediaToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem producerToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem publisherToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem ratingToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem replayGainAlbumGainToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem replayGainAlbumPeakToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem replayGainTrackGainToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem replayGainTrackPeakToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem stereoToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem subtitleToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem toolToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem trackToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem typeToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem vbrToolStripMenuItem;
+			System.Windows.Forms.ToolStripMenuItem elapsedToolStripMenuItem;
+			System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(SettingsDialog));
+			this.otherToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileBasenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.fileBasenameWithoutExtensionToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.writeToFileLabel = new System.Windows.Forms.Label();
+			this.textFilenameEditor = new System.Windows.Forms.SaveFileDialog();
+			this.textBrowseButton = new System.Windows.Forms.Button();
+			this.textFilename = new System.Windows.Forms.TextBox();
+			this.templateLabel = new System.Windows.Forms.Label();
+			this.templateEditor = new System.Windows.Forms.TextBox();
+			this.templateInsertButton = new System.Windows.Forms.Button();
+			this.okButton = new System.Windows.Forms.Button();
+			this.cancelButton = new System.Windows.Forms.Button();
+			this.templatePreview = new System.Windows.Forms.TextBox();
+			this.previewLabel = new System.Windows.Forms.Label();
+			this.insertTemplatePlaceholderMenu = new System.Windows.Forms.ContextMenuStrip(this.components);
+			this.toolStripSeparator1 = new System.Windows.Forms.ToolStripSeparator();
+			this.ifToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.ifElseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.newLineToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.toolStripSeparator2 = new System.Windows.Forms.ToolStripSeparator();
+			this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.explanationLabel = new System.Windows.Forms.Label();
+			this.horizontalRule1 = new System.Windows.Forms.Label();
+			this.applyButton = new System.Windows.Forms.Button();
+			this.albumArtLabel = new System.Windows.Forms.Label();
+			this.albumArtBrowseButton = new System.Windows.Forms.Button();
+			this.albumArtFilename = new System.Windows.Forms.TextBox();
+			this.albumArtFilenameEditor = new System.Windows.Forms.SaveFileDialog();
+			this.writeToFile2Label = new System.Windows.Forms.Label();
+			this.text2BrowseButton = new System.Windows.Forms.Button();
+			this.text2Filename = new System.Windows.Forms.TextBox();
+			this.template2Label = new System.Windows.Forms.Label();
+			this.preview2Label = new System.Windows.Forms.Label();
+			this.template2Editor = new System.Windows.Forms.TextBox();
+			this.template2InsertButton = new System.Windows.Forms.Button();
+			this.template2Preview = new System.Windows.Forms.TextBox();
+			albumToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			artistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			filenameToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			titleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			yearToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			albumArtistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			bitrateToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			bpmToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			categoryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			commentToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			composerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			conductorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			directorToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			discToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			familyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			gainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			genreToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			isrcToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			keyToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			lengthToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			losslessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			lyricistToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			mediaToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			producerToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			publisherToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			ratingToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			replayGainAlbumGainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			replayGainAlbumPeakToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			replayGainTrackGainToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			replayGainTrackPeakToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			stereoToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			subtitleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			toolToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			trackToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			typeToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			vbrToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			elapsedToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+			this.insertTemplatePlaceholderMenu.SuspendLayout();
+			this.SuspendLayout();
+			// 
+			// albumToolStripMenuItem
+			// 
+			albumToolStripMenuItem.Name = "albumToolStripMenuItem";
+			albumToolStripMenuItem.ShowShortcutKeys = false;
+			albumToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			albumToolStripMenuItem.Text = "Album";
+			// 
+			// artistToolStripMenuItem
+			// 
+			artistToolStripMenuItem.Name = "artistToolStripMenuItem";
+			artistToolStripMenuItem.ShowShortcutKeys = false;
+			artistToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			artistToolStripMenuItem.Text = "Artist";
+			// 
+			// filenameToolStripMenuItem
+			// 
+			filenameToolStripMenuItem.Name = "filenameToolStripMenuItem";
+			filenameToolStripMenuItem.ShowShortcutKeys = false;
+			filenameToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			filenameToolStripMenuItem.Text = "Filename";
+			filenameToolStripMenuItem.ToolTipText = "The absolute path to the file, e.g. \"C:\\Users\\Ben\\Music\\Song.mp3\"";
+			// 
+			// titleToolStripMenuItem
+			// 
+			titleToolStripMenuItem.Name = "titleToolStripMenuItem";
+			titleToolStripMenuItem.ShowShortcutKeys = false;
+			titleToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			titleToolStripMenuItem.Text = "Title";
+			// 
+			// yearToolStripMenuItem
+			// 
+			yearToolStripMenuItem.Name = "yearToolStripMenuItem";
+			yearToolStripMenuItem.ShowShortcutKeys = false;
+			yearToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			yearToolStripMenuItem.Text = "Year";
+			// 
+			// albumArtistToolStripMenuItem
+			// 
+			albumArtistToolStripMenuItem.Name = "albumArtistToolStripMenuItem";
+			albumArtistToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			albumArtistToolStripMenuItem.Tag = "AlbumArtist";
+			albumArtistToolStripMenuItem.Text = "Album artist";
+			// 
+			// bitrateToolStripMenuItem
+			// 
+			bitrateToolStripMenuItem.Name = "bitrateToolStripMenuItem";
+			bitrateToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			bitrateToolStripMenuItem.Text = "Bitrate";
+			bitrateToolStripMenuItem.ToolTipText = "Number of kilobits per second, e.g. \"320\"";
+			// 
+			// bpmToolStripMenuItem
+			// 
+			bpmToolStripMenuItem.Name = "bpmToolStripMenuItem";
+			bpmToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			bpmToolStripMenuItem.Tag = "BPM";
+			bpmToolStripMenuItem.Text = "BPM";
+			bpmToolStripMenuItem.ToolTipText = "Number of beats per minute, e.g. \"86\"";
+			// 
+			// categoryToolStripMenuItem
+			// 
+			categoryToolStripMenuItem.Name = "categoryToolStripMenuItem";
+			categoryToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			categoryToolStripMenuItem.Text = "Category";
+			categoryToolStripMenuItem.ToolTipText = "e.g. \"Rock\"";
+			// 
+			// commentToolStripMenuItem
+			// 
+			commentToolStripMenuItem.Name = "commentToolStripMenuItem";
+			commentToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			commentToolStripMenuItem.Text = "Comment";
+			// 
+			// composerToolStripMenuItem
+			// 
+			composerToolStripMenuItem.Name = "composerToolStripMenuItem";
+			composerToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			composerToolStripMenuItem.Text = "Composer";
+			// 
+			// conductorToolStripMenuItem
+			// 
+			conductorToolStripMenuItem.Name = "conductorToolStripMenuItem";
+			conductorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			conductorToolStripMenuItem.Text = "Conductor";
+			// 
+			// directorToolStripMenuItem
+			// 
+			directorToolStripMenuItem.Name = "directorToolStripMenuItem";
+			directorToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			directorToolStripMenuItem.Text = "Director";
+			directorToolStripMenuItem.ToolTipText = "For video files";
+			// 
+			// discToolStripMenuItem
+			// 
+			discToolStripMenuItem.Name = "discToolStripMenuItem";
+			discToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			discToolStripMenuItem.Text = "Disc";
+			discToolStripMenuItem.ToolTipText = "e.g. \"1\" or \"1/2\"";
+			// 
+			// familyToolStripMenuItem
+			// 
+			familyToolStripMenuItem.Name = "familyToolStripMenuItem";
+			familyToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			familyToolStripMenuItem.Text = "Family";
+			familyToolStripMenuItem.ToolTipText = "e.g. \"MPEG Layer 3 Audio File\"";
+			// 
+			// gainToolStripMenuItem
+			// 
+			gainToolStripMenuItem.Name = "gainToolStripMenuItem";
+			gainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			gainToolStripMenuItem.Text = "Gain";
+			gainToolStripMenuItem.ToolTipText = "e.g. \"+0.40 dB\"";
+			// 
+			// genreToolStripMenuItem
+			// 
+			genreToolStripMenuItem.Name = "genreToolStripMenuItem";
+			genreToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			genreToolStripMenuItem.Text = "Genre";
+			// 
+			// isrcToolStripMenuItem
+			// 
+			isrcToolStripMenuItem.Name = "isrcToolStripMenuItem";
+			isrcToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			isrcToolStripMenuItem.Tag = "ISRC";
+			isrcToolStripMenuItem.Text = "ISRC";
+			isrcToolStripMenuItem.ToolTipText = "e.g. \"USLZJ2006066\"";
+			// 
+			// keyToolStripMenuItem
+			// 
+			keyToolStripMenuItem.Name = "keyToolStripMenuItem";
+			keyToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			keyToolStripMenuItem.Text = "Key";
+			keyToolStripMenuItem.ToolTipText = "e.g. \"A\"";
+			// 
+			// lengthToolStripMenuItem
+			// 
+			lengthToolStripMenuItem.Name = "lengthToolStripMenuItem";
+			lengthToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			lengthToolStripMenuItem.Tag = "Length:m\\:ss";
+			lengthToolStripMenuItem.Text = "Length";
+			lengthToolStripMenuItem.ToolTipText = "Duration of media with millisecond resolution, to be formatted as a .NET TimeSpan" +
     "";
-            // 
-            // losslessToolStripMenuItem
-            // 
-            losslessToolStripMenuItem.Name = "losslessToolStripMenuItem";
-            losslessToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            losslessToolStripMenuItem.Text = "Lossless";
-            losslessToolStripMenuItem.ToolTipText = "\"0\" (lossy) or \"1\" (lossless)";
-            // 
-            // lyricistToolStripMenuItem
-            // 
-            lyricistToolStripMenuItem.Name = "lyricistToolStripMenuItem";
-            lyricistToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            lyricistToolStripMenuItem.Text = "Lyricist";
-            // 
-            // mediaToolStripMenuItem
-            // 
-            mediaToolStripMenuItem.Name = "mediaToolStripMenuItem";
-            mediaToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            mediaToolStripMenuItem.Text = "Media";
-            mediaToolStripMenuItem.ToolTipText = "The MEDIATYPE ID3v2 tag";
-            // 
-            // producerToolStripMenuItem
-            // 
-            producerToolStripMenuItem.Name = "producerToolStripMenuItem";
-            producerToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            producerToolStripMenuItem.Text = "Producer";
-            // 
-            // publisherToolStripMenuItem
-            // 
-            publisherToolStripMenuItem.Name = "publisherToolStripMenuItem";
-            publisherToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            publisherToolStripMenuItem.Text = "Publisher";
-            // 
-            // ratingToolStripMenuItem
-            // 
-            ratingToolStripMenuItem.Name = "ratingToolStripMenuItem";
-            ratingToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            ratingToolStripMenuItem.Text = "Rating";
-            ratingToolStripMenuItem.ToolTipText = "\"1\", \"2\", \"3\", \"4\", \"5\", or empty";
-            // 
-            // replayGainAlbumGainToolStripMenuItem
-            // 
-            replayGainAlbumGainToolStripMenuItem.Name = "replayGainAlbumGainToolStripMenuItem";
-            replayGainAlbumGainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            replayGainAlbumGainToolStripMenuItem.Tag = "ReplayGain_Album_Gain";
-            replayGainAlbumGainToolStripMenuItem.Text = "ReplayGain album gain";
-            replayGainAlbumGainToolStripMenuItem.ToolTipText = "e.g. \"-7.29 dB\"";
-            // 
-            // replayGainAlbumPeakToolStripMenuItem
-            // 
-            replayGainAlbumPeakToolStripMenuItem.Name = "replayGainAlbumPeakToolStripMenuItem";
-            replayGainAlbumPeakToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            replayGainAlbumPeakToolStripMenuItem.Tag = "ReplayGain_Album_Peak";
-            replayGainAlbumPeakToolStripMenuItem.Text = "ReplayGain album peak";
-            replayGainAlbumPeakToolStripMenuItem.ToolTipText = "e.g. \"0.965118408\"";
-            // 
-            // replayGainTrackGainToolStripMenuItem
-            // 
-            replayGainTrackGainToolStripMenuItem.Name = "replayGainTrackGainToolStripMenuItem";
-            replayGainTrackGainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            replayGainTrackGainToolStripMenuItem.Tag = "ReplayGain_Track_Gain";
-            replayGainTrackGainToolStripMenuItem.Text = "ReplayGain track gain";
-            replayGainTrackGainToolStripMenuItem.ToolTipText = "e.g. \"-7.29 dB\"";
-            // 
-            // replayGainTrackPeakToolStripMenuItem
-            // 
-            replayGainTrackPeakToolStripMenuItem.Name = "replayGainTrackPeakToolStripMenuItem";
-            replayGainTrackPeakToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            replayGainTrackPeakToolStripMenuItem.Tag = "ReplayGain_Track_Peak";
-            replayGainTrackPeakToolStripMenuItem.Text = "ReplayGain track peak";
-            replayGainTrackPeakToolStripMenuItem.ToolTipText = "e.g. \"0.965118408\"";
-            // 
-            // stereoToolStripMenuItem
-            // 
-            stereoToolStripMenuItem.Name = "stereoToolStripMenuItem";
-            stereoToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            stereoToolStripMenuItem.Text = "Stereo";
-            stereoToolStripMenuItem.ToolTipText = "\"0\" (mono) or \"1\" (stereo)";
-            // 
-            // subtitleToolStripMenuItem
-            // 
-            subtitleToolStripMenuItem.Name = "subtitleToolStripMenuItem";
-            subtitleToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            subtitleToolStripMenuItem.Text = "Subtitle";
-            // 
-            // toolToolStripMenuItem
-            // 
-            toolToolStripMenuItem.Name = "toolToolStripMenuItem";
-            toolToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            toolToolStripMenuItem.Text = "Tool";
-            toolToolStripMenuItem.ToolTipText = "The ENCODEDBY ID3v2 tag, e.g. \"iTunes 10.5.1\"";
-            // 
-            // trackToolStripMenuItem
-            // 
-            trackToolStripMenuItem.Name = "trackToolStripMenuItem";
-            trackToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            trackToolStripMenuItem.Text = "Track";
-            trackToolStripMenuItem.ToolTipText = "e.g. \"1\" or \"1/5\"";
-            // 
-            // typeToolStripMenuItem
-            // 
-            typeToolStripMenuItem.Name = "typeToolStripMenuItem";
-            typeToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            typeToolStripMenuItem.Text = "Type";
-            typeToolStripMenuItem.ToolTipText = "\"0\" (audio) or \"1\" (video)";
-            // 
-            // vbrToolStripMenuItem
-            // 
-            vbrToolStripMenuItem.Name = "vbrToolStripMenuItem";
-            vbrToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            vbrToolStripMenuItem.Tag = "VBR";
-            vbrToolStripMenuItem.Text = "VBR";
-            vbrToolStripMenuItem.ToolTipText = "\"0\" (constant bitrate) or \"1\" (variable bitrate)";
-            // 
-            // elapsedToolStripMenuItem
-            // 
-            elapsedToolStripMenuItem.Name = "elapsedToolStripMenuItem";
-            elapsedToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            elapsedToolStripMenuItem.Tag = "Elapsed:m\\:ss";
-            elapsedToolStripMenuItem.Text = "Elapsed";
-            elapsedToolStripMenuItem.ToolTipText = "Playback time position of the current media with millisecond resolution, updated " +
+			// 
+			// losslessToolStripMenuItem
+			// 
+			losslessToolStripMenuItem.Name = "losslessToolStripMenuItem";
+			losslessToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			losslessToolStripMenuItem.Text = "Lossless";
+			losslessToolStripMenuItem.ToolTipText = "\"0\" (lossy) or \"1\" (lossless)";
+			// 
+			// lyricistToolStripMenuItem
+			// 
+			lyricistToolStripMenuItem.Name = "lyricistToolStripMenuItem";
+			lyricistToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			lyricistToolStripMenuItem.Text = "Lyricist";
+			// 
+			// mediaToolStripMenuItem
+			// 
+			mediaToolStripMenuItem.Name = "mediaToolStripMenuItem";
+			mediaToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			mediaToolStripMenuItem.Text = "Media";
+			mediaToolStripMenuItem.ToolTipText = "The MEDIATYPE ID3v2 tag";
+			// 
+			// producerToolStripMenuItem
+			// 
+			producerToolStripMenuItem.Name = "producerToolStripMenuItem";
+			producerToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			producerToolStripMenuItem.Text = "Producer";
+			// 
+			// publisherToolStripMenuItem
+			// 
+			publisherToolStripMenuItem.Name = "publisherToolStripMenuItem";
+			publisherToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			publisherToolStripMenuItem.Text = "Publisher";
+			// 
+			// ratingToolStripMenuItem
+			// 
+			ratingToolStripMenuItem.Name = "ratingToolStripMenuItem";
+			ratingToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			ratingToolStripMenuItem.Text = "Rating";
+			ratingToolStripMenuItem.ToolTipText = "\"1\", \"2\", \"3\", \"4\", \"5\", or empty";
+			// 
+			// replayGainAlbumGainToolStripMenuItem
+			// 
+			replayGainAlbumGainToolStripMenuItem.Name = "replayGainAlbumGainToolStripMenuItem";
+			replayGainAlbumGainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			replayGainAlbumGainToolStripMenuItem.Tag = "ReplayGain_Album_Gain";
+			replayGainAlbumGainToolStripMenuItem.Text = "ReplayGain album gain";
+			replayGainAlbumGainToolStripMenuItem.ToolTipText = "e.g. \"-7.29 dB\"";
+			// 
+			// replayGainAlbumPeakToolStripMenuItem
+			// 
+			replayGainAlbumPeakToolStripMenuItem.Name = "replayGainAlbumPeakToolStripMenuItem";
+			replayGainAlbumPeakToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			replayGainAlbumPeakToolStripMenuItem.Tag = "ReplayGain_Album_Peak";
+			replayGainAlbumPeakToolStripMenuItem.Text = "ReplayGain album peak";
+			replayGainAlbumPeakToolStripMenuItem.ToolTipText = "e.g. \"0.965118408\"";
+			// 
+			// replayGainTrackGainToolStripMenuItem
+			// 
+			replayGainTrackGainToolStripMenuItem.Name = "replayGainTrackGainToolStripMenuItem";
+			replayGainTrackGainToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			replayGainTrackGainToolStripMenuItem.Tag = "ReplayGain_Track_Gain";
+			replayGainTrackGainToolStripMenuItem.Text = "ReplayGain track gain";
+			replayGainTrackGainToolStripMenuItem.ToolTipText = "e.g. \"-7.29 dB\"";
+			// 
+			// replayGainTrackPeakToolStripMenuItem
+			// 
+			replayGainTrackPeakToolStripMenuItem.Name = "replayGainTrackPeakToolStripMenuItem";
+			replayGainTrackPeakToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			replayGainTrackPeakToolStripMenuItem.Tag = "ReplayGain_Track_Peak";
+			replayGainTrackPeakToolStripMenuItem.Text = "ReplayGain track peak";
+			replayGainTrackPeakToolStripMenuItem.ToolTipText = "e.g. \"0.965118408\"";
+			// 
+			// stereoToolStripMenuItem
+			// 
+			stereoToolStripMenuItem.Name = "stereoToolStripMenuItem";
+			stereoToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			stereoToolStripMenuItem.Text = "Stereo";
+			stereoToolStripMenuItem.ToolTipText = "\"0\" (mono) or \"1\" (stereo)";
+			// 
+			// subtitleToolStripMenuItem
+			// 
+			subtitleToolStripMenuItem.Name = "subtitleToolStripMenuItem";
+			subtitleToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			subtitleToolStripMenuItem.Text = "Subtitle";
+			// 
+			// toolToolStripMenuItem
+			// 
+			toolToolStripMenuItem.Name = "toolToolStripMenuItem";
+			toolToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			toolToolStripMenuItem.Text = "Tool";
+			toolToolStripMenuItem.ToolTipText = "The ENCODEDBY ID3v2 tag, e.g. \"iTunes 10.5.1\"";
+			// 
+			// trackToolStripMenuItem
+			// 
+			trackToolStripMenuItem.Name = "trackToolStripMenuItem";
+			trackToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			trackToolStripMenuItem.Text = "Track";
+			trackToolStripMenuItem.ToolTipText = "e.g. \"1\" or \"1/5\"";
+			// 
+			// typeToolStripMenuItem
+			// 
+			typeToolStripMenuItem.Name = "typeToolStripMenuItem";
+			typeToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			typeToolStripMenuItem.Text = "Type";
+			typeToolStripMenuItem.ToolTipText = "\"0\" (audio) or \"1\" (video)";
+			// 
+			// vbrToolStripMenuItem
+			// 
+			vbrToolStripMenuItem.Name = "vbrToolStripMenuItem";
+			vbrToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			vbrToolStripMenuItem.Tag = "VBR";
+			vbrToolStripMenuItem.Text = "VBR";
+			vbrToolStripMenuItem.ToolTipText = "\"0\" (constant bitrate) or \"1\" (variable bitrate)";
+			// 
+			// elapsedToolStripMenuItem
+			// 
+			elapsedToolStripMenuItem.Name = "elapsedToolStripMenuItem";
+			elapsedToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			elapsedToolStripMenuItem.Tag = "Elapsed:m\\:ss";
+			elapsedToolStripMenuItem.Text = "Elapsed";
+			elapsedToolStripMenuItem.ToolTipText = "Playback time position of the current media with millisecond resolution, updated " +
     "every second. To be formatted as a .NET TimeSpan.";
-            // 
-            // otherToolStripMenuItem
-            // 
-            this.otherToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			// 
+			// otherToolStripMenuItem
+			// 
+			this.otherToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
             albumArtistToolStripMenuItem,
             bitrateToolStripMenuItem,
             bpmToolStripMenuItem,
@@ -435,140 +443,140 @@
             trackToolStripMenuItem,
             typeToolStripMenuItem,
             vbrToolStripMenuItem});
-            this.otherToolStripMenuItem.Name = "otherToolStripMenuItem";
-            this.otherToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.otherToolStripMenuItem.Text = "More";
-            this.otherToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.onTemplateMenuSelection);
-            // 
-            // fileBasenameToolStripMenuItem
-            // 
-            this.fileBasenameToolStripMenuItem.Name = "fileBasenameToolStripMenuItem";
-            this.fileBasenameToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.fileBasenameToolStripMenuItem.Tag = "FileBasename";
-            this.fileBasenameToolStripMenuItem.Text = "File basename";
-            this.fileBasenameToolStripMenuItem.ToolTipText = "Name of file without path, e.g. \"Song.mp3\"";
-            // 
-            // fileBasenameWithoutExtensionToolStripMenuItem
-            // 
-            this.fileBasenameWithoutExtensionToolStripMenuItem.Name = "fileBasenameWithoutExtensionToolStripMenuItem";
-            this.fileBasenameWithoutExtensionToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
-            this.fileBasenameWithoutExtensionToolStripMenuItem.Tag = "FileBasenameWithoutExtension";
-            this.fileBasenameWithoutExtensionToolStripMenuItem.Text = "File basename without extension";
-            this.fileBasenameWithoutExtensionToolStripMenuItem.ToolTipText = "Name of file without path or extension, e.g. \"Song\"";
-            // 
-            // writeToFileLabel
-            // 
-            this.writeToFileLabel.AutoSize = true;
-            this.writeToFileLabel.Location = new System.Drawing.Point(13, 76);
-            this.writeToFileLabel.Name = "writeToFileLabel";
-            this.writeToFileLabel.Size = new System.Drawing.Size(66, 13);
-            this.writeToFileLabel.TabIndex = 5;
-            this.writeToFileLabel.Text = "&Save text as";
-            // 
-            // textFilenameEditor
-            // 
-            this.textFilenameEditor.DefaultExt = "txt";
-            this.textFilenameEditor.Filter = "Text files|*.txt";
-            this.textFilenameEditor.Title = "Choose file to save Now Playing text into";
-            this.textFilenameEditor.FileOk += new System.ComponentModel.CancelEventHandler(this.onSubmitFilename);
-            // 
-            // textBrowseButton
-            // 
-            this.textBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.textBrowseButton.Location = new System.Drawing.Point(499, 71);
-            this.textBrowseButton.Name = "textBrowseButton";
-            this.textBrowseButton.Size = new System.Drawing.Size(75, 23);
-            this.textBrowseButton.TabIndex = 7;
-            this.textBrowseButton.Text = "&Browse…";
-            this.textBrowseButton.UseVisualStyleBackColor = true;
-            this.textBrowseButton.Click += new System.EventHandler(this.onTextFileBrowseButtonClick);
-            // 
-            // textFilename
-            // 
-            this.textFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.otherToolStripMenuItem.Name = "otherToolStripMenuItem";
+			this.otherToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			this.otherToolStripMenuItem.Text = "More";
+			this.otherToolStripMenuItem.DropDownItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.onTemplateMenuSelection);
+			// 
+			// fileBasenameToolStripMenuItem
+			// 
+			this.fileBasenameToolStripMenuItem.Name = "fileBasenameToolStripMenuItem";
+			this.fileBasenameToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			this.fileBasenameToolStripMenuItem.Tag = "FileBasename";
+			this.fileBasenameToolStripMenuItem.Text = "File basename";
+			this.fileBasenameToolStripMenuItem.ToolTipText = "Name of file without path, e.g. \"Song.mp3\"";
+			// 
+			// fileBasenameWithoutExtensionToolStripMenuItem
+			// 
+			this.fileBasenameWithoutExtensionToolStripMenuItem.Name = "fileBasenameWithoutExtensionToolStripMenuItem";
+			this.fileBasenameWithoutExtensionToolStripMenuItem.Size = new System.Drawing.Size(247, 22);
+			this.fileBasenameWithoutExtensionToolStripMenuItem.Tag = "FileBasenameWithoutExtension";
+			this.fileBasenameWithoutExtensionToolStripMenuItem.Text = "File basename without extension";
+			this.fileBasenameWithoutExtensionToolStripMenuItem.ToolTipText = "Name of file without path or extension, e.g. \"Song\"";
+			// 
+			// writeToFileLabel
+			// 
+			this.writeToFileLabel.AutoSize = true;
+			this.writeToFileLabel.Location = new System.Drawing.Point(13, 76);
+			this.writeToFileLabel.Name = "writeToFileLabel";
+			this.writeToFileLabel.Size = new System.Drawing.Size(66, 13);
+			this.writeToFileLabel.TabIndex = 5;
+			this.writeToFileLabel.Text = "&Save text as";
+			// 
+			// textFilenameEditor
+			// 
+			this.textFilenameEditor.DefaultExt = "txt";
+			this.textFilenameEditor.Filter = "Text files|*.txt";
+			this.textFilenameEditor.Title = "Choose file to save Now Playing text into";
+			this.textFilenameEditor.FileOk += new System.ComponentModel.CancelEventHandler(this.onSubmitFilename);
+			// 
+			// textBrowseButton
+			// 
+			this.textBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.textBrowseButton.Location = new System.Drawing.Point(499, 71);
+			this.textBrowseButton.Name = "textBrowseButton";
+			this.textBrowseButton.Size = new System.Drawing.Size(75, 23);
+			this.textBrowseButton.TabIndex = 7;
+			this.textBrowseButton.Text = "&Browse…";
+			this.textBrowseButton.UseVisualStyleBackColor = true;
+			this.textBrowseButton.Click += new System.EventHandler(this.onTextFileBrowseButtonClick);
+			// 
+			// textFilename
+			// 
+			this.textFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.textFilename.Location = new System.Drawing.Point(127, 73);
-            this.textFilename.Name = "textFilename";
-            this.textFilename.Size = new System.Drawing.Size(366, 20);
-            this.textFilename.TabIndex = 6;
-            this.textFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
-            // 
-            // templateLabel
-            // 
-            this.templateLabel.AutoSize = true;
-            this.templateLabel.Location = new System.Drawing.Point(13, 18);
-            this.templateLabel.Name = "templateLabel";
-            this.templateLabel.Size = new System.Drawing.Size(71, 13);
-            this.templateLabel.TabIndex = 0;
-            this.templateLabel.Text = "&Text template";
-            // 
-            // templateEditor
-            // 
-            this.templateEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.textFilename.Location = new System.Drawing.Point(140, 73);
+			this.textFilename.Name = "textFilename";
+			this.textFilename.Size = new System.Drawing.Size(353, 20);
+			this.textFilename.TabIndex = 6;
+			this.textFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
+			// 
+			// templateLabel
+			// 
+			this.templateLabel.AutoSize = true;
+			this.templateLabel.Location = new System.Drawing.Point(13, 18);
+			this.templateLabel.Name = "templateLabel";
+			this.templateLabel.Size = new System.Drawing.Size(71, 13);
+			this.templateLabel.TabIndex = 0;
+			this.templateLabel.Text = "&Text template";
+			// 
+			// templateEditor
+			// 
+			this.templateEditor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.templateEditor.Location = new System.Drawing.Point(127, 15);
-            this.templateEditor.Name = "templateEditor";
-            this.templateEditor.Size = new System.Drawing.Size(366, 20);
-            this.templateEditor.TabIndex = 1;
-            this.templateEditor.TextChanged += new System.EventHandler(this.onTemplateChange);
-            // 
-            // templateInsertButton
-            // 
-            this.templateInsertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.templateInsertButton.Location = new System.Drawing.Point(499, 13);
-            this.templateInsertButton.Name = "templateInsertButton";
-            this.templateInsertButton.Size = new System.Drawing.Size(75, 23);
-            this.templateInsertButton.TabIndex = 2;
-            this.templateInsertButton.Text = "&Insert";
-            this.templateInsertButton.UseVisualStyleBackColor = true;
-            this.templateInsertButton.Click += new System.EventHandler(this.showTemplateMenu);
-            // 
-            // okButton
-            // 
-            this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.okButton.Location = new System.Drawing.Point(337, 196);
-            this.okButton.Name = "okButton";
-            this.okButton.Size = new System.Drawing.Size(75, 23);
-            this.okButton.TabIndex = 13;
-            this.okButton.Text = "OK";
-            this.okButton.UseVisualStyleBackColor = true;
-            this.okButton.Click += new System.EventHandler(this.onClickOk);
-            // 
-            // cancelButton
-            // 
-            this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-            this.cancelButton.Location = new System.Drawing.Point(418, 196);
-            this.cancelButton.Name = "cancelButton";
-            this.cancelButton.Size = new System.Drawing.Size(75, 23);
-            this.cancelButton.TabIndex = 14;
-            this.cancelButton.Text = "Cancel";
-            this.cancelButton.UseVisualStyleBackColor = true;
-            this.cancelButton.Click += new System.EventHandler(this.onCancel);
-            // 
-            // templatePreview
-            // 
-            this.templatePreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.templateEditor.Location = new System.Drawing.Point(140, 15);
+			this.templateEditor.Name = "templateEditor";
+			this.templateEditor.Size = new System.Drawing.Size(353, 20);
+			this.templateEditor.TabIndex = 1;
+			this.templateEditor.TextChanged += new System.EventHandler(this.onTemplateChange);
+			// 
+			// templateInsertButton
+			// 
+			this.templateInsertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.templateInsertButton.Location = new System.Drawing.Point(499, 13);
+			this.templateInsertButton.Name = "templateInsertButton";
+			this.templateInsertButton.Size = new System.Drawing.Size(75, 23);
+			this.templateInsertButton.TabIndex = 2;
+			this.templateInsertButton.Text = "&Insert";
+			this.templateInsertButton.UseVisualStyleBackColor = true;
+			this.templateInsertButton.Click += new System.EventHandler(this.showTemplateMenu);
+			// 
+			// okButton
+			// 
+			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.okButton.Location = new System.Drawing.Point(337, 267);
+			this.okButton.Name = "okButton";
+			this.okButton.Size = new System.Drawing.Size(75, 23);
+			this.okButton.TabIndex = 13;
+			this.okButton.Text = "OK";
+			this.okButton.UseVisualStyleBackColor = true;
+			this.okButton.Click += new System.EventHandler(this.onClickOk);
+			// 
+			// cancelButton
+			// 
+			this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
+			this.cancelButton.Location = new System.Drawing.Point(418, 267);
+			this.cancelButton.Name = "cancelButton";
+			this.cancelButton.Size = new System.Drawing.Size(75, 23);
+			this.cancelButton.TabIndex = 14;
+			this.cancelButton.Text = "Cancel";
+			this.cancelButton.UseVisualStyleBackColor = true;
+			this.cancelButton.Click += new System.EventHandler(this.onCancel);
+			// 
+			// templatePreview
+			// 
+			this.templatePreview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.templatePreview.Location = new System.Drawing.Point(127, 44);
-            this.templatePreview.Name = "templatePreview";
-            this.templatePreview.ReadOnly = true;
-            this.templatePreview.Size = new System.Drawing.Size(447, 20);
-            this.templatePreview.TabIndex = 4;
-            this.templatePreview.TabStop = false;
-            // 
-            // previewLabel
-            // 
-            this.previewLabel.AutoSize = true;
-            this.previewLabel.Location = new System.Drawing.Point(13, 47);
-            this.previewLabel.Name = "previewLabel";
-            this.previewLabel.Size = new System.Drawing.Size(68, 13);
-            this.previewLabel.TabIndex = 3;
-            this.previewLabel.Text = "Text preview";
-            // 
-            // insertTemplatePlaceholderMenu
-            // 
-            this.insertTemplatePlaceholderMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
+			this.templatePreview.Location = new System.Drawing.Point(140, 44);
+			this.templatePreview.Name = "templatePreview";
+			this.templatePreview.ReadOnly = true;
+			this.templatePreview.Size = new System.Drawing.Size(434, 20);
+			this.templatePreview.TabIndex = 4;
+			this.templatePreview.TabStop = false;
+			// 
+			// previewLabel
+			// 
+			this.previewLabel.AutoSize = true;
+			this.previewLabel.Location = new System.Drawing.Point(13, 47);
+			this.previewLabel.Name = "previewLabel";
+			this.previewLabel.Size = new System.Drawing.Size(68, 13);
+			this.previewLabel.TabIndex = 3;
+			this.previewLabel.Text = "Text preview";
+			// 
+			// insertTemplatePlaceholderMenu
+			// 
+			this.insertTemplatePlaceholderMenu.Items.AddRange(new System.Windows.Forms.ToolStripItem[] {
             albumToolStripMenuItem,
             artistToolStripMenuItem,
             filenameToolStripMenuItem,
@@ -581,148 +589,236 @@
             this.newLineToolStripMenuItem,
             this.toolStripSeparator2,
             this.helpToolStripMenuItem});
-            this.insertTemplatePlaceholderMenu.Name = "insertTemplatePlaceholderMenu";
-            this.insertTemplatePlaceholderMenu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
-            this.insertTemplatePlaceholderMenu.ShowImageMargin = false;
-            this.insertTemplatePlaceholderMenu.Size = new System.Drawing.Size(156, 258);
-            this.insertTemplatePlaceholderMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.onTemplateMenuSelection);
-            // 
-            // toolStripSeparator1
-            // 
-            this.toolStripSeparator1.Name = "toolStripSeparator1";
-            this.toolStripSeparator1.Size = new System.Drawing.Size(152, 6);
-            // 
-            // ifToolStripMenuItem
-            // 
-            this.ifToolStripMenuItem.Name = "ifToolStripMenuItem";
-            this.ifToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.ifToolStripMenuItem.Text = "If";
-            // 
-            // ifElseToolStripMenuItem
-            // 
-            this.ifElseToolStripMenuItem.Name = "ifElseToolStripMenuItem";
-            this.ifElseToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.ifElseToolStripMenuItem.Text = "If else";
-            // 
-            // newLineToolStripMenuItem
-            // 
-            this.newLineToolStripMenuItem.Name = "newLineToolStripMenuItem";
-            this.newLineToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.newLineToolStripMenuItem.Text = "New line";
-            // 
-            // toolStripSeparator2
-            // 
-            this.toolStripSeparator2.Name = "toolStripSeparator2";
-            this.toolStripSeparator2.Size = new System.Drawing.Size(152, 6);
-            // 
-            // helpToolStripMenuItem
-            // 
-            this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
-            this.helpToolStripMenuItem.Size = new System.Drawing.Size(155, 22);
-            this.helpToolStripMenuItem.Text = "Help";
-            // 
-            // explanationLabel
-            // 
-            this.explanationLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.insertTemplatePlaceholderMenu.Name = "insertTemplatePlaceholderMenu";
+			this.insertTemplatePlaceholderMenu.RenderMode = System.Windows.Forms.ToolStripRenderMode.System;
+			this.insertTemplatePlaceholderMenu.ShowImageMargin = false;
+			this.insertTemplatePlaceholderMenu.Size = new System.Drawing.Size(96, 236);
+			this.insertTemplatePlaceholderMenu.ItemClicked += new System.Windows.Forms.ToolStripItemClickedEventHandler(this.onTemplateMenuSelection);
+			// 
+			// toolStripSeparator1
+			// 
+			this.toolStripSeparator1.Name = "toolStripSeparator1";
+			this.toolStripSeparator1.Size = new System.Drawing.Size(92, 6);
+			// 
+			// ifToolStripMenuItem
+			// 
+			this.ifToolStripMenuItem.Name = "ifToolStripMenuItem";
+			this.ifToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			this.ifToolStripMenuItem.Text = "If";
+			// 
+			// ifElseToolStripMenuItem
+			// 
+			this.ifElseToolStripMenuItem.Name = "ifElseToolStripMenuItem";
+			this.ifElseToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			this.ifElseToolStripMenuItem.Text = "If else";
+			// 
+			// newLineToolStripMenuItem
+			// 
+			this.newLineToolStripMenuItem.Name = "newLineToolStripMenuItem";
+			this.newLineToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			this.newLineToolStripMenuItem.Text = "New line";
+			// 
+			// toolStripSeparator2
+			// 
+			this.toolStripSeparator2.Name = "toolStripSeparator2";
+			this.toolStripSeparator2.Size = new System.Drawing.Size(92, 6);
+			// 
+			// helpToolStripMenuItem
+			// 
+			this.helpToolStripMenuItem.Name = "helpToolStripMenuItem";
+			this.helpToolStripMenuItem.Size = new System.Drawing.Size(95, 22);
+			this.helpToolStripMenuItem.Text = "Help";
+			// 
+			// explanationLabel
+			// 
+			this.explanationLabel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.explanationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
-            this.explanationLabel.Location = new System.Drawing.Point(22, 148);
-            this.explanationLabel.Name = "explanationLabel";
-            this.explanationLabel.Size = new System.Drawing.Size(544, 30);
-            this.explanationLabel.TabIndex = 12;
-            this.explanationLabel.Text = "When Winamp plays a track, this plug-in will save the track information and album" +
+			this.explanationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+			this.explanationLabel.Location = new System.Drawing.Point(30, 234);
+			this.explanationLabel.Name = "explanationLabel";
+			this.explanationLabel.Size = new System.Drawing.Size(544, 30);
+			this.explanationLabel.TabIndex = 12;
+			this.explanationLabel.Text = "When Winamp plays a track, this plug-in will save the track information and album" +
     " art to files. The format of the text can be customized with the template.";
-            // 
-            // horizontalRule1
-            // 
-            this.horizontalRule1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			// 
+			// horizontalRule1
+			// 
+			this.horizontalRule1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.horizontalRule1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
-            this.horizontalRule1.Location = new System.Drawing.Point(17, 136);
-            this.horizontalRule1.Name = "horizontalRule1";
-            this.horizontalRule1.Size = new System.Drawing.Size(555, 2);
-            this.horizontalRule1.TabIndex = 11;
-            // 
-            // applyButton
-            // 
-            this.applyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.applyButton.Location = new System.Drawing.Point(499, 196);
-            this.applyButton.Name = "applyButton";
-            this.applyButton.Size = new System.Drawing.Size(75, 23);
-            this.applyButton.TabIndex = 15;
-            this.applyButton.Text = "&Apply";
-            this.applyButton.UseVisualStyleBackColor = true;
-            this.applyButton.Click += new System.EventHandler(this.onClickApply);
-            // 
-            // albumArtLabel
-            // 
-            this.albumArtLabel.AutoSize = true;
-            this.albumArtLabel.Location = new System.Drawing.Point(13, 105);
-            this.albumArtLabel.Name = "albumArtLabel";
-            this.albumArtLabel.Size = new System.Drawing.Size(92, 13);
-            this.albumArtLabel.TabIndex = 8;
-            this.albumArtLabel.Text = "Save a&lbum art as";
-            // 
-            // albumArtBrowseButton
-            // 
-            this.albumArtBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
-            this.albumArtBrowseButton.Location = new System.Drawing.Point(499, 100);
-            this.albumArtBrowseButton.Name = "albumArtBrowseButton";
-            this.albumArtBrowseButton.Size = new System.Drawing.Size(75, 23);
-            this.albumArtBrowseButton.TabIndex = 10;
-            this.albumArtBrowseButton.Text = "B&rowse…";
-            this.albumArtBrowseButton.UseVisualStyleBackColor = true;
-            this.albumArtBrowseButton.Click += new System.EventHandler(this.onAlbumArtBrowseButtonClick);
-            // 
-            // albumArtFilename
-            // 
-            this.albumArtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+			this.horizontalRule1.BorderStyle = System.Windows.Forms.BorderStyle.Fixed3D;
+			this.horizontalRule1.Location = new System.Drawing.Point(16, 219);
+			this.horizontalRule1.Name = "horizontalRule1";
+			this.horizontalRule1.Size = new System.Drawing.Size(555, 2);
+			this.horizontalRule1.TabIndex = 11;
+			// 
+			// applyButton
+			// 
+			this.applyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
+			this.applyButton.Location = new System.Drawing.Point(499, 267);
+			this.applyButton.Name = "applyButton";
+			this.applyButton.Size = new System.Drawing.Size(75, 23);
+			this.applyButton.TabIndex = 15;
+			this.applyButton.Text = "&Apply";
+			this.applyButton.UseVisualStyleBackColor = true;
+			this.applyButton.Click += new System.EventHandler(this.onClickApply);
+			// 
+			// albumArtLabel
+			// 
+			this.albumArtLabel.AutoSize = true;
+			this.albumArtLabel.Location = new System.Drawing.Point(13, 192);
+			this.albumArtLabel.Name = "albumArtLabel";
+			this.albumArtLabel.Size = new System.Drawing.Size(92, 13);
+			this.albumArtLabel.TabIndex = 8;
+			this.albumArtLabel.Text = "Save a&lbum art as";
+			// 
+			// albumArtBrowseButton
+			// 
+			this.albumArtBrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.albumArtBrowseButton.Location = new System.Drawing.Point(499, 187);
+			this.albumArtBrowseButton.Name = "albumArtBrowseButton";
+			this.albumArtBrowseButton.Size = new System.Drawing.Size(75, 23);
+			this.albumArtBrowseButton.TabIndex = 10;
+			this.albumArtBrowseButton.Text = "B&rowse…";
+			this.albumArtBrowseButton.UseVisualStyleBackColor = true;
+			this.albumArtBrowseButton.Click += new System.EventHandler(this.onAlbumArtBrowseButtonClick);
+			// 
+			// albumArtFilename
+			// 
+			this.albumArtFilename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
-            this.albumArtFilename.Location = new System.Drawing.Point(127, 102);
-            this.albumArtFilename.Name = "albumArtFilename";
-            this.albumArtFilename.Size = new System.Drawing.Size(366, 20);
-            this.albumArtFilename.TabIndex = 9;
-            this.albumArtFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
-            // 
-            // albumArtFilenameEditor
-            // 
-            this.albumArtFilenameEditor.DefaultExt = "png";
-            this.albumArtFilenameEditor.Filter = "Image files|*.jpg,*.png";
-            this.albumArtFilenameEditor.Title = "Choose file to save Now Playing album art into";
-            this.albumArtFilenameEditor.FileOk += new System.ComponentModel.CancelEventHandler(this.onSubmitFilename);
-            // 
-            // SettingsDialog
-            // 
-            this.AcceptButton = this.okButton;
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
-            this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.CancelButton = this.cancelButton;
-            this.ClientSize = new System.Drawing.Size(586, 232);
-            this.Controls.Add(this.applyButton);
-            this.Controls.Add(this.horizontalRule1);
-            this.Controls.Add(this.explanationLabel);
-            this.Controls.Add(this.templatePreview);
-            this.Controls.Add(this.cancelButton);
-            this.Controls.Add(this.okButton);
-            this.Controls.Add(this.templateInsertButton);
-            this.Controls.Add(this.templateEditor);
-            this.Controls.Add(this.previewLabel);
-            this.Controls.Add(this.templateLabel);
-            this.Controls.Add(this.albumArtFilename);
-            this.Controls.Add(this.textFilename);
-            this.Controls.Add(this.albumArtBrowseButton);
-            this.Controls.Add(this.textBrowseButton);
-            this.Controls.Add(this.albumArtLabel);
-            this.Controls.Add(this.writeToFileLabel);
-            this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
-            this.MaximizeBox = false;
-            this.MinimizeBox = false;
-            this.Name = "SettingsDialog";
-            this.Text = "Now Playing to File plug-in configuration";
-            this.Load += new System.EventHandler(this.SettingsDialog_Load);
-            this.insertTemplatePlaceholderMenu.ResumeLayout(false);
-            this.ResumeLayout(false);
-            this.PerformLayout();
+			this.albumArtFilename.Location = new System.Drawing.Point(140, 189);
+			this.albumArtFilename.Name = "albumArtFilename";
+			this.albumArtFilename.Size = new System.Drawing.Size(353, 20);
+			this.albumArtFilename.TabIndex = 9;
+			this.albumArtFilename.TextChanged += new System.EventHandler(this.onFilenameChange);
+			// 
+			// albumArtFilenameEditor
+			// 
+			this.albumArtFilenameEditor.DefaultExt = "png";
+			this.albumArtFilenameEditor.Filter = "Image files|*.jpg,*.png";
+			this.albumArtFilenameEditor.Title = "Choose file to save Now Playing album art into";
+			this.albumArtFilenameEditor.FileOk += new System.ComponentModel.CancelEventHandler(this.onSubmitFilename);
+			// 
+			// writeToFile2Label
+			// 
+			this.writeToFile2Label.AutoSize = true;
+			this.writeToFile2Label.Location = new System.Drawing.Point(13, 163);
+			this.writeToFile2Label.Name = "writeToFile2Label";
+			this.writeToFile2Label.Size = new System.Drawing.Size(118, 13);
+			this.writeToFile2Label.TabIndex = 5;
+			this.writeToFile2Label.Text = "&Save secondary text as";
+			// 
+			// text2BrowseButton
+			// 
+			this.text2BrowseButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.text2BrowseButton.Location = new System.Drawing.Point(499, 158);
+			this.text2BrowseButton.Name = "text2BrowseButton";
+			this.text2BrowseButton.Size = new System.Drawing.Size(75, 23);
+			this.text2BrowseButton.TabIndex = 7;
+			this.text2BrowseButton.Text = "&Browse…";
+			this.text2BrowseButton.UseVisualStyleBackColor = true;
+			this.text2BrowseButton.Click += new System.EventHandler(this.onTextFileBrowseButtonClick);
+			// 
+			// text2Filename
+			// 
+			this.text2Filename.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.text2Filename.Location = new System.Drawing.Point(140, 160);
+			this.text2Filename.Name = "text2Filename";
+			this.text2Filename.Size = new System.Drawing.Size(353, 20);
+			this.text2Filename.TabIndex = 6;
+			this.text2Filename.TextChanged += new System.EventHandler(this.onFilenameChange);
+			// 
+			// template2Label
+			// 
+			this.template2Label.AutoSize = true;
+			this.template2Label.Location = new System.Drawing.Point(13, 105);
+			this.template2Label.Name = "template2Label";
+			this.template2Label.Size = new System.Drawing.Size(121, 13);
+			this.template2Label.TabIndex = 0;
+			this.template2Label.Text = "&Secondary text template";
+			// 
+			// preview2Label
+			// 
+			this.preview2Label.AutoSize = true;
+			this.preview2Label.Location = new System.Drawing.Point(13, 134);
+			this.preview2Label.Name = "preview2Label";
+			this.preview2Label.Size = new System.Drawing.Size(118, 13);
+			this.preview2Label.TabIndex = 3;
+			this.preview2Label.Text = "Secondary text preview";
+			// 
+			// template2Editor
+			// 
+			this.template2Editor.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.template2Editor.Location = new System.Drawing.Point(140, 102);
+			this.template2Editor.Name = "template2Editor";
+			this.template2Editor.Size = new System.Drawing.Size(353, 20);
+			this.template2Editor.TabIndex = 1;
+			this.template2Editor.TextChanged += new System.EventHandler(this.onTemplateChange);
+			// 
+			// template2InsertButton
+			// 
+			this.template2InsertButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
+			this.template2InsertButton.Location = new System.Drawing.Point(499, 100);
+			this.template2InsertButton.Name = "template2InsertButton";
+			this.template2InsertButton.Size = new System.Drawing.Size(75, 23);
+			this.template2InsertButton.TabIndex = 2;
+			this.template2InsertButton.Text = "&Insert";
+			this.template2InsertButton.UseVisualStyleBackColor = true;
+			this.template2InsertButton.Click += new System.EventHandler(this.showTemplateMenu);
+			// 
+			// template2Preview
+			// 
+			this.template2Preview.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+			this.template2Preview.Location = new System.Drawing.Point(140, 131);
+			this.template2Preview.Name = "template2Preview";
+			this.template2Preview.ReadOnly = true;
+			this.template2Preview.Size = new System.Drawing.Size(434, 20);
+			this.template2Preview.TabIndex = 4;
+			this.template2Preview.TabStop = false;
+			// 
+			// SettingsDialog
+			// 
+			this.AcceptButton = this.okButton;
+			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+			this.CancelButton = this.cancelButton;
+			this.ClientSize = new System.Drawing.Size(586, 303);
+			this.Controls.Add(this.applyButton);
+			this.Controls.Add(this.horizontalRule1);
+			this.Controls.Add(this.explanationLabel);
+			this.Controls.Add(this.template2Preview);
+			this.Controls.Add(this.templatePreview);
+			this.Controls.Add(this.cancelButton);
+			this.Controls.Add(this.okButton);
+			this.Controls.Add(this.template2InsertButton);
+			this.Controls.Add(this.templateInsertButton);
+			this.Controls.Add(this.template2Editor);
+			this.Controls.Add(this.templateEditor);
+			this.Controls.Add(this.preview2Label);
+			this.Controls.Add(this.previewLabel);
+			this.Controls.Add(this.template2Label);
+			this.Controls.Add(this.templateLabel);
+			this.Controls.Add(this.albumArtFilename);
+			this.Controls.Add(this.text2Filename);
+			this.Controls.Add(this.textFilename);
+			this.Controls.Add(this.text2BrowseButton);
+			this.Controls.Add(this.albumArtBrowseButton);
+			this.Controls.Add(this.textBrowseButton);
+			this.Controls.Add(this.writeToFile2Label);
+			this.Controls.Add(this.albumArtLabel);
+			this.Controls.Add(this.writeToFileLabel);
+			this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
+			this.MaximizeBox = false;
+			this.MinimizeBox = false;
+			this.Name = "SettingsDialog";
+			this.Text = "Now Playing to File plug-in configuration";
+			this.Load += new System.EventHandler(this.SettingsDialog_Load);
+			this.insertTemplatePlaceholderMenu.ResumeLayout(false);
+			this.ResumeLayout(false);
+			this.PerformLayout();
 
         }
 
@@ -756,5 +852,13 @@
         private System.Windows.Forms.ToolStripMenuItem fileBasenameToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem fileBasenameWithoutExtensionToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem otherToolStripMenuItem;
-    }
+		private System.Windows.Forms.Label writeToFile2Label;
+		private System.Windows.Forms.Button text2BrowseButton;
+		private System.Windows.Forms.TextBox text2Filename;
+		private System.Windows.Forms.Label template2Label;
+		private System.Windows.Forms.Label preview2Label;
+		private System.Windows.Forms.TextBox template2Editor;
+		private System.Windows.Forms.Button template2InsertButton;
+		private System.Windows.Forms.TextBox template2Preview;
+	}
 }

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.Designer.cs
@@ -530,7 +530,7 @@
 			// okButton
 			// 
 			this.okButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.okButton.Location = new System.Drawing.Point(337, 220);
+			this.okButton.Location = new System.Drawing.Point(337, 226);
 			this.okButton.Name = "okButton";
 			this.okButton.Size = new System.Drawing.Size(75, 23);
 			this.okButton.TabIndex = 13;
@@ -542,7 +542,7 @@
 			// 
 			this.cancelButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
 			this.cancelButton.DialogResult = System.Windows.Forms.DialogResult.Cancel;
-			this.cancelButton.Location = new System.Drawing.Point(418, 220);
+			this.cancelButton.Location = new System.Drawing.Point(418, 226);
 			this.cancelButton.Name = "cancelButton";
 			this.cancelButton.Size = new System.Drawing.Size(75, 23);
 			this.cancelButton.TabIndex = 14;
@@ -632,10 +632,9 @@
 			this.explanationLabel.Font = new System.Drawing.Font("Microsoft Sans Serif", 8F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
 			this.explanationLabel.Location = new System.Drawing.Point(30, 170);
 			this.explanationLabel.Name = "explanationLabel";
-			this.explanationLabel.Size = new System.Drawing.Size(544, 30);
+			this.explanationLabel.Size = new System.Drawing.Size(544, 49);
 			this.explanationLabel.TabIndex = 12;
-			this.explanationLabel.Text = "When Winamp plays a track, this plug-in will save the track information and album" +
-    " art to files. The format of the text can be customized with the template.";
+			this.explanationLabel.Text = resources.GetString("explanationLabel.Text");
 			// 
 			// horizontalRule1
 			// 
@@ -650,7 +649,7 @@
 			// applyButton
 			// 
 			this.applyButton.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-			this.applyButton.Location = new System.Drawing.Point(499, 220);
+			this.applyButton.Location = new System.Drawing.Point(499, 226);
 			this.applyButton.Name = "applyButton";
 			this.applyButton.Size = new System.Drawing.Size(75, 23);
 			this.applyButton.TabIndex = 15;
@@ -740,7 +739,7 @@
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
 			this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
 			this.CancelButton = this.cancelButton;
-			this.ClientSize = new System.Drawing.Size(586, 256);
+			this.ClientSize = new System.Drawing.Size(586, 262);
 			this.Controls.Add(this.templateRemove);
 			this.Controls.Add(this.templateAdd);
 			this.Controls.Add(this.templateSelectorLabel);

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
@@ -272,11 +272,13 @@ public partial class SettingsDialog: Form {
         settings.textTemplates.Add(settings.getDefault());
         templateSelector.Items.Add(settings.textTemplates.Last());
         templateSelector.SelectedIndex = templateSelector.Items.Count - 1;
+        onFormDirty();
 	}
 
 	private void onTemmplateRemove(object sender, EventArgs e) {
         settings.textTemplates.Remove((textTemplate)templateSelector.SelectedItem);
         templateSelector.Items.Remove(templateSelector.SelectedItem);
 		templateSelector.SelectedIndex = templateSelector.Items.Count - 1;
+		onFormDirty();
 	}
 }

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
@@ -77,9 +77,6 @@ public partial class SettingsDialog: Form {
     }
 
     private void SettingsDialog_Load(object sender, EventArgs e) {
-        //templateEditor.Text = settings.textTemplates.First().text;
-        //templateEditor.Select(templateEditor.TextLength, 0);
-
         // Since the templateSelector holds all textTemplates let's not fire textBox events since those update the templateSelector too
         templateEditor.TextChanged -= onTemplateChange; 
         textFilename.TextChanged -= onFilenameChange; 
@@ -97,8 +94,6 @@ public partial class SettingsDialog: Form {
 		templateEditor.TextChanged += onTemplateChange;
 		textFilename.TextChanged += onFilenameChange;
 		albumArtFilename.TextChanged += onFilenameChange;
-		//onTemplateSelectorChanged(sender, e);
-
 
 		winampController.songChanged += delegate { renderPreview(templatePreview); };
         renderTextTimer.Elapsed      += delegate { renderPreview(templatePreview); };
@@ -137,9 +132,7 @@ public partial class SettingsDialog: Form {
 
     private void onTemplateChange(object sender, EventArgs e) {
         renderPreview(sender);
-        //templateSelector.SelectedIndexChanged -= onTemplateSelectorChanged;
         templateSelector.Items[templateSelector.SelectedIndex] = new textTemplate(textFilename.Text, templateEditor.Text);
-		//templateSelector.SelectedIndexChanged += onTemplateSelectorChanged;
 		onFormDirty();
     }
 
@@ -203,7 +196,6 @@ public partial class SettingsDialog: Form {
             newTemplate.Append(placeholder);
             newTemplate.Append(originalTemplate.Substring(selectionEnd));
 
-			
 			templateEditor.Text             = newTemplate.ToString();
 			templateEditor.SelectionLength = 0;
 			templateEditor.SelectionStart  = selectionStart + placeholder.Length;
@@ -232,7 +224,6 @@ public partial class SettingsDialog: Form {
         try {
             compileTemplate().Render(EXAMPLE_SONG);
 
-            //settings.textTemplates[templateSelector.SelectedIndex] = new textTemplate(textFilename.Text, templateEditor.Text);
             // Actually the templateSelector will hold all of the templates now
             settings.textTemplates = templateSelector.Items.Cast<textTemplate>().ToList();
 
@@ -271,23 +262,17 @@ public partial class SettingsDialog: Form {
 		textFilenameEditor.InitialDirectory = Path.GetDirectoryName(selectedTemplate.fileName);
 		textFilenameEditor.FileName = selectedTemplate.fileName;
 
-		//albumArtFilenameEditor.InitialDirectory = Path.GetDirectoryName(settings.albumArtFilename);
-		//albumArtFilenameEditor.FileName = settings.albumArtFilename;
-
 		textFilename.Text = selectedTemplate.fileName;
-		//albumArtFilename.Text = settings.albumArtFilename;
 
 		templateEditor.Text = selectedTemplate.text;
-		//templateEditor.Select(templateEditor.TextLength, 0);
 
-        applyButton.Enabled = applyButtonState;
+        applyButton.Enabled = applyButtonState; // Restore dirty state
 	}
 
 	private void onTemplateAdd(object sender, EventArgs e) {
         settings.textTemplates.Add(settings.getDefault());
         templateSelector.Items.Add(settings.textTemplates.Last());
         templateSelector.SelectedIndex = templateSelector.Items.Count - 1;
-        //onTemplateSelectorChanged(sender, e);
 	}
 
 	private void onTemmplateRemove(object sender, EventArgs e) {

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.cs
@@ -14,7 +14,6 @@ using System.Windows.Forms;
 using WinampNowPlayingToFile.Facade;
 using WinampNowPlayingToFile.Settings;
 using Timer = System.Timers.Timer;
-using static WinampNowPlayingToFile.Settings.ISettings;
 
 namespace WinampNowPlayingToFile.Presentation;
 

--- a/WinampNowPlayingToFile/Presentation/SettingsDialog.resx
+++ b/WinampNowPlayingToFile/Presentation/SettingsDialog.resx
@@ -234,6 +234,9 @@
   <metadata name="insertTemplatePlaceholderMenu.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>161, 17</value>
   </metadata>
+  <data name="explanationLabel.Text" xml:space="preserve">
+    <value>When Winamp plays a track, this plug-in will save the track information and album art to files. The format of the text can be customized with templates. Create more text files with different templates by adding more with the plus button. Note: All templates will be saved at once upon pressing OK or Apply.</value>
+  </data>
   <metadata name="albumArtFilenameEditor.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>374, 21</value>
   </metadata>

--- a/WinampNowPlayingToFile/Settings/BaseSettings.cs
+++ b/WinampNowPlayingToFile/Settings/BaseSettings.cs
@@ -1,25 +1,37 @@
 ﻿#nullable enable
 
 using System;
+using System.Collections.Generic;
+
+using TagLib.Riff;
+
+using static WinampNowPlayingToFile.Settings.ISettings;
 
 namespace WinampNowPlayingToFile.Settings;
 
 public abstract class BaseSettings: ISettings {
 
-    public string textFilename { get; set; } = null!;
     public string albumArtFilename { get; set; } = null!;
-    public string textTemplate { get; set; } = null!;
+    public List<textTemplate> textTemplates { get; set; } = null!;
 
-    public event EventHandler? settingsUpdated;
+	public event EventHandler? settingsUpdated;
 
     public abstract void load();
     public virtual void save() { }
 
     public ISettings loadDefaults() {
-        textFilename     = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.txt");
+        textTemplates = new List<ISettings.textTemplate>() {
+            getDefault()
+        };
         albumArtFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.png");
-        textTemplate     = "{{#if Artist}}{{Artist}} \u2013 {{/if}}{{Title}}{{#if Album}} \u2013 {{Album}}{{/if}}";
         return this;
+    }
+
+    public textTemplate getDefault() {
+        return new textTemplate(
+			fileName: Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.txt"),
+			text: "{{#if Artist}}{{Artist}} \u2013 {{/if}}{{Title}}{{#if Album}} \u2013 {{Album}}{{/if}}"
+			);
     }
 
     protected void onSettingsUpdated() {

--- a/WinampNowPlayingToFile/Settings/BaseSettings.cs
+++ b/WinampNowPlayingToFile/Settings/BaseSettings.cs
@@ -7,10 +7,8 @@ namespace WinampNowPlayingToFile.Settings;
 public abstract class BaseSettings: ISettings {
 
     public string textFilename { get; set; } = null!;
-    public string secondaryTextFilename { get; set; } = null!;
     public string albumArtFilename { get; set; } = null!;
     public string textTemplate { get; set; } = null!;
-    public string secondaryTextTemplate { get; set; } = null!;
 
     public event EventHandler? settingsUpdated;
 
@@ -19,7 +17,6 @@ public abstract class BaseSettings: ISettings {
 
     public ISettings loadDefaults() {
         textFilename     = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.txt");
-        secondaryTextFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing2.txt");
         albumArtFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.png");
         textTemplate     = "{{#if Artist}}{{Artist}} \u2013 {{/if}}{{Title}}{{#if Album}} \u2013 {{Album}}{{/if}}";
         return this;

--- a/WinampNowPlayingToFile/Settings/BaseSettings.cs
+++ b/WinampNowPlayingToFile/Settings/BaseSettings.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 
 using TagLib.Riff;
 
-using static WinampNowPlayingToFile.Settings.ISettings;
+using WinampNowPlayingToFile.Facade;
 
 namespace WinampNowPlayingToFile.Settings;
 
@@ -20,7 +20,7 @@ public abstract class BaseSettings: ISettings {
     public virtual void save() { }
 
     public ISettings loadDefaults() {
-        textTemplates = new List<ISettings.textTemplate>() {
+        textTemplates = new List<textTemplate>() {
             getDefault()
         };
         albumArtFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.png");

--- a/WinampNowPlayingToFile/Settings/BaseSettings.cs
+++ b/WinampNowPlayingToFile/Settings/BaseSettings.cs
@@ -7,8 +7,10 @@ namespace WinampNowPlayingToFile.Settings;
 public abstract class BaseSettings: ISettings {
 
     public string textFilename { get; set; } = null!;
+    public string secondaryTextFilename { get; set; } = null!;
     public string albumArtFilename { get; set; } = null!;
     public string textTemplate { get; set; } = null!;
+    public string secondaryTextTemplate { get; set; } = null!;
 
     public event EventHandler? settingsUpdated;
 
@@ -17,6 +19,7 @@ public abstract class BaseSettings: ISettings {
 
     public ISettings loadDefaults() {
         textFilename     = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.txt");
+        secondaryTextFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing2.txt");
         albumArtFilename = Environment.ExpandEnvironmentVariables(@"%TEMP%\winamp_now_playing.png");
         textTemplate     = "{{#if Artist}}{{Artist}} \u2013 {{/if}}{{Title}}{{#if Album}} \u2013 {{Album}}{{/if}}";
         return this;

--- a/WinampNowPlayingToFile/Settings/ISettings.cs
+++ b/WinampNowPlayingToFile/Settings/ISettings.cs
@@ -5,10 +5,8 @@ namespace WinampNowPlayingToFile.Settings;
 public interface ISettings {
 
     string textFilename { get; set; }
-    string secondaryTextFilename { get; set; }
     string albumArtFilename { get; set; }
     string textTemplate { get; set; }
-    string secondaryTextTemplate { get; set; }
 
     event EventHandler settingsUpdated;
 

--- a/WinampNowPlayingToFile/Settings/ISettings.cs
+++ b/WinampNowPlayingToFile/Settings/ISettings.cs
@@ -1,17 +1,33 @@
 ﻿using System;
+using System.Collections.Generic;
 
 namespace WinampNowPlayingToFile.Settings; 
 
 public interface ISettings {
 
-    string textFilename { get; set; }
+    struct textTemplate {
+		public textTemplate(string fileName = null!, string text = null!) {
+            this.fileName = fileName!;
+            this.text = text!;
+		}
+
+		public string fileName { get; set; }
+        public string text { get; set; }
+
+		public override string ToString() {
+			return text;
+		}
+	}
+
     string albumArtFilename { get; set; }
-    string textTemplate { get; set; }
+
+    abstract List<textTemplate> textTemplates { get; set; }
 
     event EventHandler settingsUpdated;
 
     void load();
     ISettings loadDefaults();
+    textTemplate getDefault();
     void save();
 
 }

--- a/WinampNowPlayingToFile/Settings/ISettings.cs
+++ b/WinampNowPlayingToFile/Settings/ISettings.cs
@@ -5,8 +5,10 @@ namespace WinampNowPlayingToFile.Settings;
 public interface ISettings {
 
     string textFilename { get; set; }
+    string secondaryTextFilename { get; set; }
     string albumArtFilename { get; set; }
     string textTemplate { get; set; }
+    string secondaryTextTemplate { get; set; }
 
     event EventHandler settingsUpdated;
 

--- a/WinampNowPlayingToFile/Settings/ISettings.cs
+++ b/WinampNowPlayingToFile/Settings/ISettings.cs
@@ -1,23 +1,11 @@
 ﻿using System;
 using System.Collections.Generic;
 
-namespace WinampNowPlayingToFile.Settings; 
+using WinampNowPlayingToFile.Facade;
 
-public interface ISettings {
+namespace WinampNowPlayingToFile.Settings;
 
-    struct textTemplate {
-		public textTemplate(string fileName = null!, string text = null!) {
-            this.fileName = fileName!;
-            this.text = text!;
-		}
-
-		public string fileName { get; set; }
-        public string text { get; set; }
-
-		public override string ToString() {
-			return text;
-		}
-	}
+public partial interface ISettings {
 
     string albumArtFilename { get; set; }
 

--- a/WinampNowPlayingToFile/Settings/RegistrySettings.cs
+++ b/WinampNowPlayingToFile/Settings/RegistrySettings.cs
@@ -1,6 +1,10 @@
 ﻿#nullable enable
 
+using System.Linq;
+
 using Microsoft.Win32;
+
+using static WinampNowPlayingToFile.Settings.ISettings;
 
 namespace WinampNowPlayingToFile.Settings;
 
@@ -13,20 +17,31 @@ public class RegistrySettings: BaseSettings {
 
         using RegistryKey? key = Registry.CurrentUser.OpenSubKey(keyPath);
         if (key != null) {
-            textFilename          = key.GetValue(nameof(textFilename)) as string ?? textFilename;
-			albumArtFilename      = key.GetValue(nameof(albumArtFilename)) as string ?? albumArtFilename;
-            textTemplate          = key.GetValue(nameof(textTemplate)) as string ?? textTemplate;
+            int savedTemplateCount = key.GetValueNames().Count(x => x.StartsWith($"{nameof(textTemplate.fileName)}"));
+            if (savedTemplateCount > 0) {
+                textTemplates.Clear();
+                for (int i = 0; i < savedTemplateCount; i++) {
+                    textTemplates.Add(new textTemplate(
+                        fileName: key.GetValue($"{nameof(textTemplate.fileName)}{i}") as string,
+                        text: key.GetValue($"{nameof(textTemplate.text)}{i}") as string
+                    ));
+                }
+                albumArtFilename = key.GetValue(nameof(albumArtFilename)) as string ?? albumArtFilename;
+            }
         }
-
     }
 
     public override void save() {
         base.save();
         using RegistryKey? key = Registry.CurrentUser.CreateSubKey(keyPath);
         if (key != null) {
-            key.SetValue(nameof(textFilename), textFilename);
-            key.SetValue(nameof(albumArtFilename), albumArtFilename);
-            key.SetValue(nameof(textTemplate), textTemplate);
+            for (int i = 0; i < textTemplates.Count; i++) {
+                textTemplate template = textTemplates[i];
+                key.SetValue($"{nameof(template.fileName)}{i}", template.fileName);
+                key.SetValue($"{nameof(template.text)}{i}", template.text);
+            }
+			key.SetValue(nameof(albumArtFilename), albumArtFilename);
+            
             onSettingsUpdated();
         }
 

--- a/WinampNowPlayingToFile/Settings/RegistrySettings.cs
+++ b/WinampNowPlayingToFile/Settings/RegistrySettings.cs
@@ -4,7 +4,7 @@ using System.Linq;
 
 using Microsoft.Win32;
 
-using static WinampNowPlayingToFile.Settings.ISettings;
+using WinampNowPlayingToFile.Facade;
 
 namespace WinampNowPlayingToFile.Settings;
 

--- a/WinampNowPlayingToFile/Settings/RegistrySettings.cs
+++ b/WinampNowPlayingToFile/Settings/RegistrySettings.cs
@@ -1,6 +1,7 @@
 ﻿#nullable enable
 
 using System.Linq;
+using System.Windows.Forms;
 
 using Microsoft.Win32;
 
@@ -33,6 +34,7 @@ public class RegistrySettings: BaseSettings {
 
     public override void save() {
         base.save();
+		Registry.CurrentUser.DeleteSubKey(keyPath); // Actually remove text templates removed in settings
         using RegistryKey? key = Registry.CurrentUser.CreateSubKey(keyPath);
         if (key != null) {
             for (int i = 0; i < textTemplates.Count; i++) {

--- a/WinampNowPlayingToFile/Settings/RegistrySettings.cs
+++ b/WinampNowPlayingToFile/Settings/RegistrySettings.cs
@@ -14,10 +14,8 @@ public class RegistrySettings: BaseSettings {
         using RegistryKey? key = Registry.CurrentUser.OpenSubKey(keyPath);
         if (key != null) {
             textFilename          = key.GetValue(nameof(textFilename)) as string ?? textFilename;
-            secondaryTextFilename = key.GetValue(nameof(textFilename)) as string ?? secondaryTextFilename;
 			albumArtFilename      = key.GetValue(nameof(albumArtFilename)) as string ?? albumArtFilename;
             textTemplate          = key.GetValue(nameof(textTemplate)) as string ?? textTemplate;
-            secondaryTextTemplate = key.GetValue(nameof(secondaryTextTemplate)) as string ?? secondaryTextTemplate;
         }
 
     }
@@ -27,7 +25,6 @@ public class RegistrySettings: BaseSettings {
         using RegistryKey? key = Registry.CurrentUser.CreateSubKey(keyPath);
         if (key != null) {
             key.SetValue(nameof(textFilename), textFilename);
-            key.SetValue(nameof(secondaryTextFilename), secondaryTextFilename);
             key.SetValue(nameof(albumArtFilename), albumArtFilename);
             key.SetValue(nameof(textTemplate), textTemplate);
             onSettingsUpdated();

--- a/WinampNowPlayingToFile/Settings/RegistrySettings.cs
+++ b/WinampNowPlayingToFile/Settings/RegistrySettings.cs
@@ -13,9 +13,11 @@ public class RegistrySettings: BaseSettings {
 
         using RegistryKey? key = Registry.CurrentUser.OpenSubKey(keyPath);
         if (key != null) {
-            textFilename     = key.GetValue(nameof(textFilename)) as string ?? textFilename;
-            albumArtFilename = key.GetValue(nameof(albumArtFilename)) as string ?? albumArtFilename;
-            textTemplate     = key.GetValue(nameof(textTemplate)) as string ?? textTemplate;
+            textFilename          = key.GetValue(nameof(textFilename)) as string ?? textFilename;
+            secondaryTextFilename = key.GetValue(nameof(textFilename)) as string ?? secondaryTextFilename;
+			albumArtFilename      = key.GetValue(nameof(albumArtFilename)) as string ?? albumArtFilename;
+            textTemplate          = key.GetValue(nameof(textTemplate)) as string ?? textTemplate;
+            secondaryTextTemplate = key.GetValue(nameof(secondaryTextTemplate)) as string ?? secondaryTextTemplate;
         }
 
     }
@@ -25,6 +27,7 @@ public class RegistrySettings: BaseSettings {
         using RegistryKey? key = Registry.CurrentUser.CreateSubKey(keyPath);
         if (key != null) {
             key.SetValue(nameof(textFilename), textFilename);
+            key.SetValue(nameof(secondaryTextFilename), secondaryTextFilename);
             key.SetValue(nameof(albumArtFilename), albumArtFilename);
             key.SetValue(nameof(textTemplate), textTemplate);
             onSettingsUpdated();

--- a/WinampNowPlayingToFile/WinampNowPlayingToFile.csproj
+++ b/WinampNowPlayingToFile/WinampNowPlayingToFile.csproj
@@ -78,6 +78,7 @@
     <Compile Include="Business\NowPlayingToFileManager.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Settings\SimpleSettings.cs" />
+    <Compile Include="Facade\textTemplate.cs" />
   </ItemGroup>
   <ItemGroup>
     <None Include="packages.lock.json" />


### PR DESCRIPTION
Just as the inception of this plugin was for OBS, my needs were also for that.  
I needed a way to format the now playing text in OBS that's not just a text source with a single style - therefore I made multiple text sources. This branch adds a virtually infinite number of text templates to the plugin by saving multiple text files.